### PR TITLE
Measurement Result Processing MutableList

### DIFF
--- a/Systems/src/main/kotlin/mathtools/systems/measurement/MQContainer.kt
+++ b/Systems/src/main/kotlin/mathtools/systems/measurement/MQContainer.kt
@@ -18,10 +18,9 @@ internal class MQContainer<Params : MQParams, Data>(
     } else false
 
     /** Return the recorded data as a list */
-    internal fun getData(): List<Data> {
-        val list = queue.toList()
+    internal fun getData(): MutableList<Data> {
+        val list = queue.toMutableList()
         queue.clear()
         return list
     }
 }
-

--- a/Systems/src/main/kotlin/mathtools/systems/measurement/MeasurementQueue.kt
+++ b/Systems/src/main/kotlin/mathtools/systems/measurement/MeasurementQueue.kt
@@ -25,7 +25,7 @@ abstract class MeasurementQueue<Params : MQParams, Data> {
 
     /** Process the data in a completed container */
     protected abstract suspend fun process(
-        params: Params, data: List<Data>)
+        params: Params, data: MutableList<Data>)
 
     /** Insert measurement parameters into the queue */
     suspend fun provideParams(vararg params: Params) {

--- a/Systems/src/main/kotlin/mathtools/systems/measurement/electrical/ElectricalMeasureQueue.kt
+++ b/Systems/src/main/kotlin/mathtools/systems/measurement/electrical/ElectricalMeasureQueue.kt
@@ -14,7 +14,7 @@ class ElectricalMeasureQueue : MeasurementQueue<
 
     override suspend fun process(
     	params: ElectricalParams, 
-    	data: List<ElectricalMeasureData>
+    	data: MutableList<ElectricalMeasureData>
     ) { coroutineScope {
     	val convertTime = 1.0e-9 	// Converting from nanoseconds
         val energy = async {


### PR DESCRIPTION
Provide more flexibility during data processing by switching to a MutableList. 
1. Allows data to be discarded as it is being processed, enabling garbage collection to reclaim this memory sooner. 
2. Convenient in situations where the data is searched, and sorted into sublists.