### PR TITLE
Lists Search Endpoint Argument

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ org.gradle.vfs.watch=false
 org.gradle.logging.level=info
 org.gradle.warning.mode=all
 org.gradle.daemon=false
-org.gradle.jvmargs="-Xmx300m"
+org.gradle.jvmargs="-Xmx256m"

--- a/lists/src/main/kotlin/mathtools/lists/DoubleList.kt
+++ b/lists/src/main/kotlin/mathtools/lists/DoubleList.kt
@@ -18,10 +18,13 @@ object DoubleList {
         start: Int = 0,
         end: Int = list.size,
     ) : List<Int> {
-        if (start < 0 || list.size < end)
+        if (start < 0 || list.isEmpty())
             return emptyList()
+        // If end is greater than list size, use list size
+        val lastIndex = if (list.size < end)
+            list.size - 1 else end - 1
         var indices: ArrayList<Int>? = null
-        for (idx in start until end) {
+        for (idx in start .. lastIndex) {
             if (list[idx] > limit) {
                 if (indices == null)
                     indices = arrayListOf(idx)
@@ -44,10 +47,13 @@ object DoubleList {
         start: Int = 0,
         end: Int = list.size,
     ) : List<Int> {
-        if (start < 0 || list.size < end)
+        if (start < 0 || list.isEmpty())
             return emptyList()
+        // If end is greater than list size, use list size
+        val lastIndex = if (list.size < end)
+            list.size - 1 else end - 1
         var indices: ArrayList<Int>? = null
-        for (idx in start until end) {
+        for (idx in start .. lastIndex) {
             if (list[idx] < limit) {
                 if (indices == null)
                     indices = arrayListOf(idx)
@@ -72,10 +78,13 @@ object DoubleList {
         start: Int = 0,
         end: Int = list.size,
     ) : List<Int> {
-        if (start < 0 || list.size < end || lowerBound > upperBound)
+        if (start < 0 || list.isEmpty() || lowerBound > upperBound)
             return emptyList()
+        // If end is greater than list size, use list size
+        val lastIndex = if (list.size < end)
+            list.size - 1 else end - 1
         var indices: ArrayList<Int>? = null
-        for (idx in start until end) {
+        for (idx in start .. lastIndex) {
             val item = list[idx]
             if (item < lowerBound || upperBound < item) {
                 if (indices == null)

--- a/lists/src/main/kotlin/mathtools/lists/DoubleList.kt
+++ b/lists/src/main/kotlin/mathtools/lists/DoubleList.kt
@@ -18,8 +18,10 @@ object DoubleList {
         start: Int = 0,
         end: Int = list.size,
     ) : List<Int> {
-        if (start < 0 || list.isEmpty())
-            return emptyList()
+        if (start < 0 || list.isEmpty()
+            || limit == Double.POSITIVE_INFINITY
+            || limit.isNaN()
+        ) return emptyList()
         // If end is greater than list size, use list size
         val lastIndex = if (list.size < end)
             list.size - 1 else end - 1
@@ -47,8 +49,10 @@ object DoubleList {
         start: Int = 0,
         end: Int = list.size,
     ) : List<Int> {
-        if (start < 0 || list.isEmpty())
-            return emptyList()
+        if (start < 0 || list.isEmpty()
+            || limit == Double.NEGATIVE_INFINITY
+            || limit.isNaN()
+        ) return emptyList()
         // If end is greater than list size, use list size
         val lastIndex = if (list.size < end)
             list.size - 1 else end - 1

--- a/lists/src/main/kotlin/mathtools/lists/DoubleList.kt
+++ b/lists/src/main/kotlin/mathtools/lists/DoubleList.kt
@@ -3,7 +3,7 @@ package mathtools.lists
 import java.math.BigDecimal
 
 /** Functions of Double typed Lists
- * Developed by DK96-OS : 2022 */
+ * @author DK96-OS : 2022 */
 object DoubleList {
 
     /** Find indices of elements greater than the limit

--- a/lists/src/main/kotlin/mathtools/lists/DoubleList.kt
+++ b/lists/src/main/kotlin/mathtools/lists/DoubleList.kt
@@ -7,16 +7,21 @@ import java.math.BigDecimal
 object DoubleList {
 
     /** Find indices of elements greater than the limit
+     * @param list A List of values to search in
+     * @param limit The lowest value that will be ignored
+     * @param start The start of the range of indices to check (inclusive)
+     * @param end The end of the range of indices to check (exclusive)
      * @return Indices of elements above limit */
     fun findGreaterThan(
         list: List<Double>,
         limit: Double,
         start: Int = 0,
+        end: Int = list.size,
     ) : List<Int> {
-        if (start < 0 || list.isEmpty())
+        if (start < 0 || list.size < end)
             return emptyList()
         var indices: ArrayList<Int>? = null
-        for (idx in start until list.size) {
+        for (idx in start until end) {
             if (list[idx] > limit) {
                 if (indices == null)
                     indices = arrayListOf(idx)
@@ -28,16 +33,21 @@ object DoubleList {
     }
 
     /** Find indices of elements less than the limit
+     * @param list A List of values to search in
+     * @param limit The greatest value that will be ignored
+     * @param start The start of the range of indices to check (inclusive)
+     * @param end The end of the range of indices to check (exclusive)
      * @return Indices of elements below limit */
     fun findLessThan(
         list: List<Double>,
         limit: Double,
         start: Int = 0,
+        end: Int = list.size,
     ) : List<Int> {
-        if (start < 0 || list.isEmpty())
+        if (start < 0 || list.size < end)
             return emptyList()
         var indices: ArrayList<Int>? = null
-        for (idx in start until list.size) {
+        for (idx in start until end) {
             if (list[idx] < limit) {
                 if (indices == null)
                     indices = arrayListOf(idx)
@@ -49,17 +59,23 @@ object DoubleList {
     }
 
     /** Find indices of elements outside of the specified boundaries
+     * @param list A List of values to search in
+     * @param lowerBound The lower limit of the boundary
+     * @param upperBound The upper limit of the boundary
+     * @param start The start of the range of indices to check (inclusive)
+     * @param end The end of the range of indices to check (exclusive)
      * @return Indices of elements out of bounds */
     fun findOutOfBounds(
         list: List<Double>,
         lowerBound: Double,
         upperBound: Double,
-        start: Int = 0
+        start: Int = 0,
+        end: Int = list.size,
     ) : List<Int> {
-        if (start < 0 || list.isEmpty() || lowerBound > upperBound)
+        if (start < 0 || list.size < end || lowerBound > upperBound)
             return emptyList()
         var indices: ArrayList<Int>? = null
-        for (idx in start until list.size) {
+        for (idx in start until end) {
             val item = list[idx]
             if (item < lowerBound || upperBound < item) {
                 if (indices == null)

--- a/lists/src/main/kotlin/mathtools/lists/DoubleList.kt
+++ b/lists/src/main/kotlin/mathtools/lists/DoubleList.kt
@@ -82,8 +82,11 @@ object DoubleList {
         start: Int = 0,
         end: Int = list.size,
     ) : List<Int> {
-        if (start < 0 || list.isEmpty() || lowerBound > upperBound)
-            return emptyList()
+        if (start < 0 || list.isEmpty()
+            || lowerBound.isNaN()
+            || upperBound.isNaN()
+            || lowerBound > upperBound
+        ) return emptyList()
         // If end is greater than list size, use list size
         val lastIndex = if (list.size < end)
             list.size - 1 else end - 1

--- a/lists/src/main/kotlin/mathtools/lists/IntList.kt
+++ b/lists/src/main/kotlin/mathtools/lists/IntList.kt
@@ -4,7 +4,7 @@ import java.math.BigInteger
 import kotlin.math.roundToLong
 
 /** Functions of Integer typed Lists
- * Developed by DK96-OS : 2022 */
+ * @author DK96-OS : 2022 */
 object IntList {
 
 	/** Find all elements greater than the limit

--- a/lists/src/main/kotlin/mathtools/lists/IntList.kt
+++ b/lists/src/main/kotlin/mathtools/lists/IntList.kt
@@ -7,7 +7,12 @@ import kotlin.math.roundToLong
  * Developed by DK96-OS : 2022 */
 object IntList {
 
-	/** Find all elements greater than the limit */
+	/** Find all elements greater than the limit
+	 * @param list A List of values to search in
+	 * @param limit The lowest value that will be ignored
+	 * @param start The start of the range of indices to check (inclusive)
+	 * @param end The end of the range of indices to check (exclusive)
+	 * @return Indices of elements above limit */
 	fun findGreaterThan(
 		list: List<Int>,
 		limit: Int,
@@ -30,7 +35,12 @@ object IntList {
 		return indices ?: emptyList()
 	}
 
-	/** Find indices of elements less than the limit */
+	/** Find indices of elements less than the limit
+	 * @param list A List of values to search in
+	 * @param limit The greatest value that will be ignored
+	 * @param start The start of the range of indices to check (inclusive)
+	 * @param end The end of the range of indices to check (exclusive)
+	 * @return Indices of elements below limit */
 	fun findLessThan(
 		list: List<Int>,
 		limit: Int,

--- a/lists/src/main/kotlin/mathtools/lists/IntList.kt
+++ b/lists/src/main/kotlin/mathtools/lists/IntList.kt
@@ -53,7 +53,12 @@ object IntList {
 		return indices ?: emptyList()
 	}
 
-	/** Find indices of elements outside of the given range */
+	/** Find indices of elements outside of the given range
+	 * @param list A List of values to search in
+	 * @param range The range of values to ignore
+	 * @param start The start of the range of indices to check (inclusive)
+	 * @param end The end of the range of indices to check (exclusive)
+	 * @return Indices of elements out of range */
 	fun findOutOfRange(
 		list: List<Int>,
 		range: IntRange,
@@ -61,13 +66,14 @@ object IntList {
 		end: Int = list.size,
 	) : List<Int> {
 		if (start < 0 || list.isEmpty()
-		    || range.first == Int.MIN_VALUE && range.last == Int.MAX_VALUE
+		    || range.first > range.last
+		    || range.first == Int.MIN_VALUE
+		    && range.last == Int.MAX_VALUE
 		) return emptyList()
 		// If end is greater than list size, use list size
 		val lastIndex = if (list.size < end)
 			list.size - 1 else end - 1
 		var indices: ArrayList<Int>? = null
-		// todo: Likely need to test case where range is single valued
 		for (idx in start .. lastIndex)
 			if (list[idx] !in range) {
 				if (indices == null)

--- a/lists/src/main/kotlin/mathtools/lists/IntList.kt
+++ b/lists/src/main/kotlin/mathtools/lists/IntList.kt
@@ -12,11 +12,15 @@ object IntList {
 		list: List<Int>,
 		limit: Int,
 		start: Int = 0,
+		end: Int = list.size,
 	) : List<Int> {
 		if (start < 0 || list.isEmpty() || limit == Int.MAX_VALUE)
 			return emptyList()
+		// If end is greater than list size, use list size
+		val lastIndex = if (list.size < end)
+			list.size - 1 else end - 1
 		var indices: ArrayList<Int>? = null
-		for (idx in start until list.size)
+		for (idx in start .. lastIndex)
 			if (list[idx] > limit) {
 				if (indices == null)
 					indices = arrayListOf(idx)
@@ -31,11 +35,15 @@ object IntList {
 		list: List<Int>,
 		limit: Int,
 		start: Int = 0,
+		end: Int = list.size,
 	) : List<Int> {
 		if (start < 0 || list.isEmpty() || limit == Int.MIN_VALUE)
 			return emptyList()
+		// If end is greater than list size, use list size
+		val lastIndex = if (list.size < end)
+			list.size - 1 else end - 1
 		var indices: ArrayList<Int>? = null
-		for (idx in start until list.size)
+		for (idx in start .. lastIndex)
 			if (list[idx] < limit) {
 				if (indices == null)
 					indices = arrayListOf(idx)
@@ -50,12 +58,17 @@ object IntList {
 		list: List<Int>,
 		range: IntRange,
 		start: Int = 0,
+		end: Int = list.size,
 	) : List<Int> {
 		if (start < 0 || list.isEmpty()
 		    || range.first == Int.MIN_VALUE && range.last == Int.MAX_VALUE
 		) return emptyList()
+		// If end is greater than list size, use list size
+		val lastIndex = if (list.size < end)
+			list.size - 1 else end - 1
 		var indices: ArrayList<Int>? = null
-		for (idx in start until list.size)
+		// todo: Likely need to test case where range is single valued
+		for (idx in start .. lastIndex)
 			if (list[idx] !in range) {
 				if (indices == null)
 					indices = arrayListOf(idx)

--- a/lists/src/main/kotlin/mathtools/lists/LongList.kt
+++ b/lists/src/main/kotlin/mathtools/lists/LongList.kt
@@ -6,16 +6,25 @@ import java.math.BigInteger
  * Developed by DK96-OS : 2022 */
 object LongList {
 
-    /** Find all elements greater than the limit */
+    /** Find all elements greater than the limit
+     * @param list A List of values to search in
+     * @param limit The lowest value that will be ignored
+     * @param start The start of the range of indices to check (inclusive)
+     * @param end The end of the range of indices to check (exclusive)
+     * @return Indices of elements above limit */
     fun findGreaterThan(
         list: List<Long>,
         limit: Long,
         start: Int = 0,
+        end: Int = list.size,
     ) : List<Int> {
-        if (start < 0 || list.isEmpty() || limit == Long.MAX_VALUE)
+        if (start < 0 || list.size < end || limit == Long.MAX_VALUE)
             return emptyList()
+        // If end is greater than list size, use list size
+        val lastIndex = if (list.size < end)
+            list.size - 1 else end - 1
         var indices: ArrayList<Int>? = null
-        for (idx in start until list.size)
+        for (idx in start .. lastIndex)
             if (list[idx] > limit) {
                 if (indices == null)
                     indices = arrayListOf(idx)
@@ -25,16 +34,25 @@ object LongList {
         return indices ?: emptyList()
     }
 
-    /** Find indices of elements less than the limit */
+    /** Find indices of elements less than the limit
+     * @param list A List of values to search in
+     * @param limit The greatest value that will be ignored
+     * @param start The start of the range of indices to check (inclusive)
+     * @param end The end of the range of indices to check (exclusive)
+     * @return Indices of elements below limit */
     fun findLessThan(
         list: List<Long>,
         limit: Long,
         start: Int = 0,
+        end: Int = list.size,
     ) : List<Int> {
         if (start < 0 || list.isEmpty() || limit == Long.MIN_VALUE)
             return emptyList()
+        // If end is greater than list size, use list size
+        val lastIndex = if (list.size < end)
+            list.size - 1 else end - 1
         var indices: ArrayList<Int>? = null
-        for (idx in start until list.size)
+        for (idx in start .. lastIndex)
             if (list[idx] < limit) {
                 if (indices == null)
                     indices = arrayListOf(idx)
@@ -44,20 +62,30 @@ object LongList {
         return indices ?: emptyList()
     }
 
-    /** Find indices of elements outside of the given range */
+    /** Find indices of elements outside of the given range
+     * @param list A List of values to search in
+     * @param range The range of values to ignore
+     * @param start The start of the range of indices to check (inclusive)
+     * @param end The end of the range of indices to check (exclusive)
+     * @return Indices of elements out of range */
     fun findOutOfRange(
         list: List<Long>,
         range: LongRange,
         start: Int = 0,
+        end: Int = list.size,
     ) : List<Int> {
         if (start < 0 || list.isEmpty()
             || range.first > range.last
             || range.first == Long.MIN_VALUE
             && range.last == Long.MAX_VALUE
         ) return emptyList()
+        // If end is greater than list size, use list size
+        val lastIndex = if (list.size < end)
+            list.size - 1 else end - 1
+        // Container for discovered indices
         var indices: ArrayList<Int>? = null
         if (range.first == range.last) {
-            for (idx in start until list.size) {
+            for (idx in start .. lastIndex) {
                 val item = list[idx]
                 if (item != range.first)
                     if (indices == null)
@@ -66,7 +94,7 @@ object LongList {
                         indices.add(idx)
             }
         } else {
-            for (idx in start until list.size) {
+            for (idx in start .. lastIndex) {
                 val item = list[idx]
                 if (item < range.first || range.last < item) {
                     if (indices == null)

--- a/lists/src/main/kotlin/mathtools/lists/LongList.kt
+++ b/lists/src/main/kotlin/mathtools/lists/LongList.kt
@@ -18,8 +18,9 @@ object LongList {
         start: Int = 0,
         end: Int = list.size,
     ) : List<Int> {
-        if (start < 0 || list.size < end || limit == Long.MAX_VALUE)
-            return emptyList()
+        if (start < 0 || list.isEmpty()
+            || limit == Long.MAX_VALUE
+        ) return emptyList()
         // If end is greater than list size, use list size
         val lastIndex = if (list.size < end)
             list.size - 1 else end - 1

--- a/lists/src/main/kotlin/mathtools/lists/LongList.kt
+++ b/lists/src/main/kotlin/mathtools/lists/LongList.kt
@@ -3,7 +3,7 @@ package mathtools.lists
 import java.math.BigInteger
 
 /** Functions of Long typed Lists
- * Developed by DK96-OS : 2022 */
+ * @author DK96-OS : 2022 */
 object LongList {
 
     /** Find all elements greater than the limit

--- a/lists/src/main/kotlin/mathtools/lists/LongList.kt
+++ b/lists/src/main/kotlin/mathtools/lists/LongList.kt
@@ -85,24 +85,13 @@ object LongList {
             list.size - 1 else end - 1
         // Container for discovered indices
         var indices: ArrayList<Int>? = null
-        if (range.first == range.last) {
-            for (idx in start .. lastIndex) {
-                val item = list[idx]
-                if (item != range.first)
-                    if (indices == null)
-                        indices = arrayListOf(idx)
-                    else
-                        indices.add(idx)
-            }
-        } else {
-            for (idx in start .. lastIndex) {
-                val item = list[idx]
-                if (item < range.first || range.last < item) {
-                    if (indices == null)
-                        indices = arrayListOf(idx)
-                    else
-                        indices.add(idx)
-                }
+        for (idx in start .. lastIndex) {
+            val item = list[idx]
+            if (item < range.first || range.last < item) {
+                if (indices == null)
+                    indices = arrayListOf(idx)
+                else
+                    indices.add(idx)
             }
         }
         return indices ?: emptyList()

--- a/lists/src/main/kotlin/mathtools/lists/NumberListConversion.kt
+++ b/lists/src/main/kotlin/mathtools/lists/NumberListConversion.kt
@@ -1,7 +1,7 @@
 package mathtools.lists
 
-/** Convert Numbered List Types
- * Developed by DK96-OS : 2022 */
+/** Converts Numbered List Types
+ * @author DK96-OS : 2022 */
 object NumberListConversion {
 
 	fun toDouble(list: List<Number>)

--- a/lists/src/main/kotlin/mathtools/lists/objects/ObjectList.kt
+++ b/lists/src/main/kotlin/mathtools/lists/objects/ObjectList.kt
@@ -1,7 +1,7 @@
 package mathtools.lists.objects
 
 /** Sorting related Group operations
- * Developed by DK96-OS : 2022 */
+ * @author DK96-OS : 2022 */
 object ObjectList {
 
     /** Remove and return the items in the list that match the selector.

--- a/lists/src/main/kotlin/mathtools/lists/objects/package-info.java
+++ b/lists/src/main/kotlin/mathtools/lists/objects/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * General List operations on Object types
+ * @author DK96-OS
+ */
+package mathtools.lists.objects;

--- a/lists/src/main/kotlin/mathtools/lists/package-info.java
+++ b/lists/src/main/kotlin/mathtools/lists/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * List operations involving numbers
+ * @author DK96-OS
+ */
+package mathtools.lists;

--- a/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListFindGreaterThanTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListFindGreaterThanTest.kt
@@ -43,47 +43,43 @@ class DoubleListFindGreaterThanTest {
 
     @Test
     fun testMaxValue() {
-        var result = findGreaterThan(
+        val res = Array<List<Int>?>(2) { null }
+        res[0] = findGreaterThan(
             maxValueList, Double.MAX_VALUE
         )
-        assertEquals(emptyList<Double>(), result)
-        result = findGreaterThan(
+        res[1] = findGreaterThan(
             maxValueList, Double.MAX_VALUE * 0.99999999
         )
-        assertEquals(1, result.size)
-        assertEquals(0, result[0])
+        assertEquals(emptyList<Double>(), res[0])
+        assertEquals(listOf(0), res[1])
     }
 
     @Test
     fun testNaN() {
-        var result = findGreaterThan(
+        val res = Array<List<Int>?>(2) { null }
+        res[0] = findGreaterThan(
             nanValueList, 3.9
         )
-        assertEquals(1, result.size)
-        assertEquals(4, result[0])
-        result = findGreaterThan(
+        res[1] = findGreaterThan(
             nanValueList, 1.9
         )
-        assertEquals(2, result.size)
-        assertEquals(2, result[0])
-        assertEquals(4, result[1])
+        assertEquals(listOf(4), res[0])
+        assertEquals(listOf(2, 4), res[1])
     }
 
     /** Finds positive infinity, not negative */
     @Test
     fun testInfinity() {
-        val positiveResult = findGreaterThan(
-            positiveInfiniteList, 3.9
+        assertEquals(
+            listOf(3, 4), findGreaterThan(
+                positiveInfiniteList, 3.9
+            )
         )
-        assertEquals(2, positiveResult.size)
-        assertEquals(3, positiveResult[0])
-        assertEquals(4, positiveResult[1])
-        // Negative Infinity
-        val negativeResult = findGreaterThan(
-            negativeInfiniteList, 3.9
+        assertEquals(
+            listOf(4), findGreaterThan(
+                negativeInfiniteList, 3.9
+            )
         )
-        assertEquals(1, negativeResult.size)
-        assertEquals(4, negativeResult[0])
     }
 
     @Test
@@ -101,14 +97,14 @@ class DoubleListFindGreaterThanTest {
 
     @Test
     fun testEndArg() {
-        val result1 = findGreaterThan(
-            u101, 78.5, 0, 101
+        val res1 = findGreaterThan(
+            u101, 78.5, 0, 105
         )
-        val result2 = findGreaterThan(
+        val res2 = findGreaterThan(
             u101, 78.5, 0, 100
         )
-        assertEquals(listOf(99, 100), result1)
-        assertEquals(listOf(99), result2)
+        assertEquals(listOf(99, 100), res1)
+        assertEquals(listOf(99), res2)
     }
 
     @Test
@@ -126,32 +122,32 @@ class DoubleListFindGreaterThanTest {
 
     @Test
     fun testBadIndexArgs() {
-        val results = Array<List<Int>?>(3) { null }
-        results[0] = findGreaterThan(
+        val res = Array<List<Int>?>(3) { null }
+        res[0] = findGreaterThan(
             u101, 77.5, 99, 99
         )
-        results[1] = findGreaterThan(
+        res[1] = findGreaterThan(
             u101, 77.5, 99, 98
         )
-        results[2] = findGreaterThan(
+        res[2] = findGreaterThan(
             u101, 77.5, -1, 98
         )
         assertEquals(
             listOf(0, 0, 0),
-            results.map { it?.size }
+            res.map { it?.size }
         )
     }
 
     @RepeatedTest(2)
     fun testShuffledList() {
         val shuffledList = u101.shuffled()
-        val result = findGreaterThan(
+        val res = findGreaterThan(
             shuffledList, 75.0
         )
-        assertEquals(5, result.size)
+        assertEquals(5, res.size)
         assertEquals(
             (76..80).toList(),
-            result.map { shuffledList[it].roundToInt() }.sorted()
+            res.map { shuffledList[it].roundToInt() }.sorted()
         )
     }
 

--- a/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListFindGreaterThanTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListFindGreaterThanTest.kt
@@ -88,14 +88,15 @@ class DoubleListFindGreaterThanTest {
 
     @Test
     fun testStartArg() {
-        val result1 = findGreaterThan(
+        val res = Array<List<Int>?>(2) { null }
+        res[0] = findGreaterThan(
             u101, 78.5, 90
         )
-        val result2 = findGreaterThan(
+        res[1] = findGreaterThan(
             u101, 78.5, 100
         )
-        assertEquals(listOf(99, 100), result1)
-        assertEquals(listOf(100), result2)
+        assertEquals(listOf(99, 100), res[0])
+        assertEquals(listOf(100), res[1])
     }
 
     @Test
@@ -112,14 +113,15 @@ class DoubleListFindGreaterThanTest {
 
     @Test
     fun testSublistSearch() {
-        val result1 = findGreaterThan(
-            u101, 77.5, 99, 101
+        val res = Array<List<Int>?>(2) { null }
+        res[0] = findGreaterThan(
+            u101, 77.5, 95, 100
         )
-        val result2 = findGreaterThan(
-            u101, 77.5, 99, 100
+        res[1] = findGreaterThan(
+            u101.reversed(), 77.5, 1, 5
         )
-        assertEquals(listOf(99, 100), result1)
-        assertEquals(listOf(99), result2)
+        assertEquals(listOf(98, 99), res[0])
+        assertEquals(listOf(1, 2), res[1])
     }
 
     @Test
@@ -141,14 +143,15 @@ class DoubleListFindGreaterThanTest {
     }
 
     @RepeatedTest(2)
-    fun testRandomized() {
+    fun testShuffledList() {
+        val shuffledList = u101.shuffled()
         val result = findGreaterThan(
-            u101.shuffled(), 75.0
+            shuffledList, 75.0
         )
         assertEquals(5, result.size)
         assertEquals(
             (76..80).toList(),
-            result.map { u101[it].roundToInt() }.sorted()
+            result.map { shuffledList[it].roundToInt() }.sorted()
         )
     }
 

--- a/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListFindGreaterThanTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListFindGreaterThanTest.kt
@@ -1,6 +1,7 @@
 package mathtools.lists.doubles
 
-import mathtools.lists.DoubleList
+import mathtools.lists.DoubleList.findGreaterThan
+import mathtools.lists.NumberListConversion.toDouble
 import mathtools.lists.doubles.DoubleListTestResources.largeList
 import mathtools.lists.doubles.DoubleListTestResources.largeListFactor
 import mathtools.lists.doubles.DoubleListTestResources.maxValueList
@@ -12,29 +13,32 @@ import mathtools.lists.doubles.DoubleListTestResources.positiveInfiniteList
 import mathtools.lists.doubles.DoubleListTestResources.singleItemList
 import mathtools.lists.doubles.DoubleListTestResources.smallList
 import mathtools.lists.doubles.DoubleListTestResources.smallListFactor
+import mathtools.lists.testdata.ListDataSource.uniform101
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 
 /** Testing the Greater Than function for Double typed Lists */
-class DoubleListGreaterThanTest {
+class DoubleListFindGreaterThanTest {
+
+    private val u101 = toDouble(uniform101)
 
     /** Greater Than function finds the right number of
      * elements in the small, medium, and large lists
      */
     @RepeatedTest(2)
     fun testFindGreaterThanRandomized() {
-        var result = DoubleList.findGreaterThan(
+        var result = findGreaterThan(
             smallList.shuffled(),
             smallListFactor * 8 - 0.0001
         )
         assertEquals(3, result.size)
-        result = DoubleList.findGreaterThan(
+        result = findGreaterThan(
             medList.shuffled(),
             medListFactor * 900
         )
         assertEquals(100, result.size)
-        result = DoubleList.findGreaterThan(
+        result = findGreaterThan(
             largeList.shuffled(),
             largeListFactor * 120_000
         )
@@ -44,17 +48,17 @@ class DoubleListGreaterThanTest {
     /** Greater Than works on single item and empty lists */
     @Test
     fun testFindGreaterThanSingleItem() {
-        var result = DoubleList.findGreaterThan(
+        var result = findGreaterThan(
             singleItemList, 5.0
         )
         assertEquals(emptyList<Double>(), result)
-        result = DoubleList.findGreaterThan(
+        result = findGreaterThan(
             singleItemList, 4.9999999
         )
         assertEquals(1, result.size)
         assertEquals(0, result[0])
         // Empty List
-        result = DoubleList.findGreaterThan(
+        result = findGreaterThan(
             emptyList(), 4.999
         )
         assertEquals(emptyList<Double>(), result)
@@ -63,11 +67,11 @@ class DoubleListGreaterThanTest {
     /** Greater Than works with the Max Value */
     @Test
     fun testFindGreaterThanMaxValue() {
-        var result = DoubleList.findGreaterThan(
+        var result = findGreaterThan(
             maxValueList, Double.MAX_VALUE
         )
         assertEquals(emptyList<Double>(), result)
-        result = DoubleList.findGreaterThan(
+        result = findGreaterThan(
             maxValueList, Double.MAX_VALUE * 0.99999999
         )
         assertEquals(1, result.size)
@@ -77,12 +81,12 @@ class DoubleListGreaterThanTest {
     /** Greater Than ignores Non Numerical elements */
     @Test
     fun testFindGreaterThanNaN() {
-        var result = DoubleList.findGreaterThan(
+        var result = findGreaterThan(
             nanValueList, 3.9
         )
         assertEquals(1, result.size)
         assertEquals(4, result[0])
-        result = DoubleList.findGreaterThan(
+        result = findGreaterThan(
             nanValueList, 1.9
         )
         assertEquals(2, result.size)
@@ -93,18 +97,72 @@ class DoubleListGreaterThanTest {
     /** Greater Than finds positive infinity, not negative */
     @Test
     fun testFindGreaterThanInfinity() {
-        var result = DoubleList.findGreaterThan(
+        var result = findGreaterThan(
             positiveInfiniteList, 3.9
         )
         assertEquals(2, result.size)
         assertEquals(3, result[0])
         assertEquals(4, result[1])
         // Negative Infinity
-        result = DoubleList.findGreaterThan(
+        result = findGreaterThan(
             negativeInfiniteList, 3.9
         )
         assertEquals(1, result.size)
         assertEquals(4, result[0])
+    }
+
+    @Test
+    fun testStartArg() {
+        val result1 = findGreaterThan(
+            u101, 78.5, 90
+        )
+        val result2 = findGreaterThan(
+            u101, 78.5, 100
+        )
+        assertEquals(listOf(99, 100), result1)
+        assertEquals(listOf(100), result2)
+    }
+
+    @Test
+    fun testEndArg() {
+        val result1 = findGreaterThan(
+            u101, 78.5, 0, 101
+        )
+        val result2 = findGreaterThan(
+            u101, 78.5, 0, 100
+        )
+        assertEquals(listOf(99, 100), result1)
+        assertEquals(listOf(99), result2)
+    }
+
+    @Test
+    fun testSublistSearch() {
+        val result1 = findGreaterThan(
+            u101, 77.5, 99, 101
+        )
+        val result2 = findGreaterThan(
+            u101, 77.5, 99, 100
+        )
+        assertEquals(listOf(99, 100), result1)
+        assertEquals(listOf(99), result2)
+    }
+
+    @Test
+    fun testBadIndexArgs() {
+        val results = Array<List<Int>?>(3) { null }
+        results[0] = findGreaterThan(
+            u101, 77.5, 99, 99
+        )
+        results[1] = findGreaterThan(
+            u101, 77.5, 99, 98
+        )
+        results[2] = findGreaterThan(
+            u101, 77.5, -1, 98
+        )
+        assertEquals(
+            listOf(0, 0, 0),
+            results.map { it?.size }
+        )
     }
 
 }

--- a/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListFindGreaterThanTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListFindGreaterThanTest.kt
@@ -2,71 +2,46 @@ package mathtools.lists.doubles
 
 import mathtools.lists.DoubleList.findGreaterThan
 import mathtools.lists.NumberListConversion.toDouble
-import mathtools.lists.doubles.DoubleListTestResources.largeList
-import mathtools.lists.doubles.DoubleListTestResources.largeListFactor
 import mathtools.lists.doubles.DoubleListTestResources.maxValueList
-import mathtools.lists.doubles.DoubleListTestResources.medList
-import mathtools.lists.doubles.DoubleListTestResources.medListFactor
 import mathtools.lists.doubles.DoubleListTestResources.nanValueList
 import mathtools.lists.doubles.DoubleListTestResources.negativeInfiniteList
 import mathtools.lists.doubles.DoubleListTestResources.positiveInfiniteList
-import mathtools.lists.doubles.DoubleListTestResources.singleItemList
-import mathtools.lists.doubles.DoubleListTestResources.smallList
-import mathtools.lists.doubles.DoubleListTestResources.smallListFactor
 import mathtools.lists.testdata.ListDataSource.uniform101
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
+import kotlin.math.roundToInt
 
 /** Testing the Greater Than function for Double typed Lists */
 class DoubleListFindGreaterThanTest {
 
     private val u101 = toDouble(uniform101)
 
-    /** Greater Than function finds the right number of
-     * elements in the small, medium, and large lists
-     */
-    @RepeatedTest(2)
-    fun testFindGreaterThanRandomized() {
-        var result = findGreaterThan(
-            smallList.shuffled(),
-            smallListFactor * 8 - 0.0001
+    @Test
+    fun testSingleItem() {
+        assertEquals(
+            0, findGreaterThan(
+                listOf(5.0), 5.0
+            ).size
         )
-        assertEquals(3, result.size)
-        result = findGreaterThan(
-            medList.shuffled(),
-            medListFactor * 900
+        assertEquals(
+            listOf(0), findGreaterThan(
+                listOf(5.0), 4.9999999
+            )
         )
-        assertEquals(100, result.size)
-        result = findGreaterThan(
-            largeList.shuffled(),
-            largeListFactor * 120_000
-        )
-        assertEquals(30_000, result.size)
     }
 
-    /** Greater Than works on single item and empty lists */
     @Test
-    fun testFindGreaterThanSingleItem() {
-        var result = findGreaterThan(
-            singleItemList, 5.0
+    fun testEmptyList() {
+        assertEquals(
+            0, findGreaterThan(
+                emptyList(), 4.999
+            ).size
         )
-        assertEquals(emptyList<Double>(), result)
-        result = findGreaterThan(
-            singleItemList, 4.9999999
-        )
-        assertEquals(1, result.size)
-        assertEquals(0, result[0])
-        // Empty List
-        result = findGreaterThan(
-            emptyList(), 4.999
-        )
-        assertEquals(emptyList<Double>(), result)
     }
 
-    /** Greater Than works with the Max Value */
     @Test
-    fun testFindGreaterThanMaxValue() {
+    fun testMaxValue() {
         var result = findGreaterThan(
             maxValueList, Double.MAX_VALUE
         )
@@ -78,9 +53,8 @@ class DoubleListFindGreaterThanTest {
         assertEquals(0, result[0])
     }
 
-    /** Greater Than ignores Non Numerical elements */
     @Test
-    fun testFindGreaterThanNaN() {
+    fun testNaN() {
         var result = findGreaterThan(
             nanValueList, 3.9
         )
@@ -94,21 +68,21 @@ class DoubleListFindGreaterThanTest {
         assertEquals(4, result[1])
     }
 
-    /** Greater Than finds positive infinity, not negative */
+    /** Finds positive infinity, not negative */
     @Test
-    fun testFindGreaterThanInfinity() {
-        var result = findGreaterThan(
+    fun testInfinity() {
+        val positiveResult = findGreaterThan(
             positiveInfiniteList, 3.9
         )
-        assertEquals(2, result.size)
-        assertEquals(3, result[0])
-        assertEquals(4, result[1])
+        assertEquals(2, positiveResult.size)
+        assertEquals(3, positiveResult[0])
+        assertEquals(4, positiveResult[1])
         // Negative Infinity
-        result = findGreaterThan(
+        val negativeResult = findGreaterThan(
             negativeInfiniteList, 3.9
         )
-        assertEquals(1, result.size)
-        assertEquals(4, result[0])
+        assertEquals(1, negativeResult.size)
+        assertEquals(4, negativeResult[0])
     }
 
     @Test
@@ -162,6 +136,18 @@ class DoubleListFindGreaterThanTest {
         assertEquals(
             listOf(0, 0, 0),
             results.map { it?.size }
+        )
+    }
+
+    @RepeatedTest(2)
+    fun testRandomized() {
+        val result = findGreaterThan(
+            u101.shuffled(), 75.0
+        )
+        assertEquals(5, result.size)
+        assertEquals(
+            (76..80).toList(),
+            result.map { u101[it].roundToInt() }.sorted()
         )
     }
 

--- a/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListFindGreaterThanTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListFindGreaterThanTest.kt
@@ -12,7 +12,8 @@ import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import kotlin.math.roundToInt
 
-/** Testing the Greater Than function for Double typed Lists */
+/** Testing the Greater Than function for Double typed Lists
+ * @author DK96-OS : 2022 */
 class DoubleListFindGreaterThanTest {
 
     private val u101 = toDouble(uniform101)

--- a/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListFindLessThanTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListFindLessThanTest.kt
@@ -84,15 +84,19 @@ class DoubleListFindLessThanTest {
 
 	@Test
 	fun testEndArg() {
-		val res = Array<List<Int>?>(2) { null }
+		val res = Array<List<Int>?>(3) { null }
 		res[0] = findLessThan(
 			u101, -17.5, 0, 6
 		)
 		res[1] = findLessThan(
 			u101, -17.5, 0, 2
 		)
+		res[2] = findLessThan(
+			u101, -17.5, 0, 105
+		)
 		assertEquals(listOf(0, 1, 2), res[0])
 		assertEquals(listOf(0, 1), res[1])
+		assertEquals(listOf(0, 1, 2), res[2])
 	}
 
 	@Test

--- a/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListFindLessThanTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListFindLessThanTest.kt
@@ -1,0 +1,59 @@
+package mathtools.lists.doubles
+
+import mathtools.lists.DoubleList.findLessThan
+import mathtools.lists.NumberListConversion.toDouble
+import mathtools.lists.testdata.ListDataSource.uniform101
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/** Testing the DoubleList FindLessThan function
+ * Developed by DK96-OS : 2022 */
+class DoubleListFindLessThanTest {
+
+	private val u101 = toDouble(uniform101)
+
+	@Test
+	fun testSingleItem() {}
+
+	@Test
+	fun testEmptyList() {
+		assertEquals(
+			0, findLessThan(
+				emptyList<Double>(), 10.0,
+			).size
+		)
+	}
+
+	@Test
+	fun testMaxValue() {
+		assertEquals(
+			0, findLessThan(
+				listOf(Double.MAX_VALUE), Double.MAX_VALUE
+			).size
+		)
+	}
+
+	@Test
+	fun testInfiniteLimits() {
+		assertEquals(
+			u101.size, findLessThan(
+				u101, Double.POSITIVE_INFINITY,
+			).size
+		)
+		assertEquals(
+			0, findLessThan(
+				u101, Double.NEGATIVE_INFINITY,
+			).size
+		)
+	}
+
+	@Test
+	fun testNaNLimit() {
+		assertEquals(
+			0, findLessThan(
+				u101, Double.NaN,
+			).size
+		)
+	}
+
+}

--- a/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListFindLessThanTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListFindLessThanTest.kt
@@ -4,10 +4,12 @@ import mathtools.lists.DoubleList.findLessThan
 import mathtools.lists.NumberListConversion.toDouble
 import mathtools.lists.testdata.ListDataSource.uniform101
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
+import kotlin.math.roundToInt
 
 /** Testing the DoubleList FindLessThan function
- * Developed by DK96-OS : 2022 */
+ * @author DK96-OS : 2022 */
 class DoubleListFindLessThanTest {
 
 	private val u101 = toDouble(uniform101)
@@ -64,6 +66,76 @@ class DoubleListFindLessThanTest {
 			0, findLessThan(
 				u101, Double.NaN,
 			).size
+		)
+	}
+
+	@Test
+	fun testStartArg() {
+		val res = Array<List<Int>?>(2) { null }
+		res[0] = findLessThan(
+			u101, -17.5, 1
+		)
+		res[1] = findLessThan(
+			u101.reversed(), -17.5, 99
+		)
+		assertEquals(listOf(1, 2), res[0])
+		assertEquals(listOf(99, 100), res[1])
+	}
+
+	@Test
+	fun testEndArg() {
+		val res = Array<List<Int>?>(2) { null }
+		res[0] = findLessThan(
+			u101, -17.5, 0, 6
+		)
+		res[1] = findLessThan(
+			u101, -17.5, 0, 2
+		)
+		assertEquals(listOf(0, 1, 2), res[0])
+		assertEquals(listOf(0, 1), res[1])
+	}
+
+	@Test
+	fun testSublistSearch() {
+		val res = Array<List<Int>?>(2) { null }
+		res[0] = findLessThan(
+			u101, -17.5, 1, 5
+		)
+		res[1] = findLessThan(
+			u101.reversed(), -17.5, 95, 100
+		)
+		assertEquals(listOf(1, 2), res[0])
+		assertEquals(listOf(98, 99), res[1])
+	}
+
+	@Test
+	fun testBadIndexArgs() {
+		val res = Array<List<Int>?>(3) { null }
+		res[0] = findLessThan(
+			u101, -17.5, 99, 99
+		)
+		res[1] = findLessThan(
+			u101, -17.5, 99, 98
+		)
+		res[2] = findLessThan(
+			u101, -17.5, -1, 98
+		)
+		assertEquals(
+			listOf(0, 0, 0),
+			res.map { it?.size }
+		)
+	}
+
+	@RepeatedTest(2)
+	fun testShuffledList() {
+		val shuffledList = u101.shuffled()
+		val result = findLessThan(
+			shuffledList, -15.0
+		)
+		assertEquals(5, result.size)
+		assertEquals(
+			(-20 .. -16).toList(),
+			result.map { shuffledList[it].roundToInt() }.sorted()
 		)
 	}
 

--- a/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListFindLessThanTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListFindLessThanTest.kt
@@ -13,14 +13,25 @@ class DoubleListFindLessThanTest {
 	private val u101 = toDouble(uniform101)
 
 	@Test
-	fun testSingleItem() {}
-
-	@Test
 	fun testEmptyList() {
 		assertEquals(
 			0, findLessThan(
-				emptyList<Double>(), 10.0,
+				emptyList(), 10.0,
 			).size
+		)
+	}
+
+	@Test
+	fun testSingleItem() {
+		assertEquals(
+			0, findLessThan(
+				listOf(5.5), 5.5
+			).size
+		)
+		assertEquals(
+			listOf(0), findLessThan(
+				listOf(5.5), 5.51
+			)
 		)
 	}
 

--- a/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListFindOutOfBoundsTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListFindOutOfBoundsTest.kt
@@ -202,23 +202,23 @@ class DoubleListFindOutOfBoundsTest {
 
 	@Test
 	fun testSplitSublistSearch() {
-		val results = Array<Deferred<List<Int>>?>(4) { null }
 		runBlocking {
-			for (i in 0 until 4) {
-				val startIdx = i * 25
-				val endIdx = if (i == 3)
-					101 else startIdx + 25
+			// Split search into 4 coroutines
+			val results = Array<Deferred<List<Int>>?>(4) { null }
+			val indexRangePairs = listOf(
+				0 to 24, 25 to 50, 51 to 75, 76 to 100,
+			)
+			for (i in 0 until 4)
 				results[i] = async {
 					findOutOfBounds(
 						u101, 10.0, 50.0,
-						startIdx, endIdx
+						indexRangePairs[i].first, indexRangePairs[i].second + 1
 					)
 				}
-			}
 			assertEquals(25, results[0]!!.await().size)
 			assertEquals(5, results[1]!!.await().size)
-			assertEquals(4, results[2]!!.await().size)
-			assertEquals(26, results[3]!!.await().size)
+			assertEquals(5, results[2]!!.await().size)
+			assertEquals(25, results[3]!!.await().size)
 		}
 	}
 

--- a/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListFindOutOfBoundsTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListFindOutOfBoundsTest.kt
@@ -1,5 +1,8 @@
 package mathtools.lists.doubles
 
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
 import mathtools.lists.DoubleList.findOutOfBounds
 import mathtools.lists.NumberListConversion.toDouble
 import mathtools.lists.testdata.ListDataSource.uniform101
@@ -129,6 +132,76 @@ class DoubleListFindOutOfBoundsTest {
 				u101, -200.0, -100.0
 			)
 		)
+	}
+
+	@Test
+	fun testStartArg() {
+		val result1 = findOutOfBounds(
+			u101, -10.0, 80.0, 9
+		)
+		val result2 = findOutOfBounds(
+			u101, -10.0, 80.0, 10
+		)
+		val result3 = findOutOfBounds(
+			u101, -10.0, 79.0, 9
+		)
+		assertEquals(listOf(9), result1)
+		assertEquals(0, result2.size)
+		assertEquals(listOf(9, 100), result3)
+	}
+
+	@Test
+	fun testEndArg() {
+		val result1 = findOutOfBounds(
+			u101, -20.0, 79.0, 0, 100
+		)
+		val result2 = findOutOfBounds(
+			u101, -20.0, 79.0, 0, 101
+		)
+		val result3 = findOutOfBounds(
+			u101, -19.0, 70.0, 0, 92
+		)
+		assertEquals(0, result1.size)
+		assertEquals(100, result2[0])
+		assertEquals(listOf(0, 91), result3)
+	}
+
+	@Test
+	fun testSublistSearch() {
+		val result1 = findOutOfBounds(
+			u101, -10.0, 70.0, 9, 92
+		)
+		val result2 = findOutOfBounds(
+			u101, -10.0, 70.0, 10, 92
+		)
+		val result3 = findOutOfBounds(
+			u101, -10.0, 70.0, 9, 91
+		)
+		assertEquals(listOf(9, 91), result1)
+		assertEquals(91, result2[0])
+		assertEquals(9, result3[0])
+	}
+
+	@Test
+	fun testSplitSublistSearch() {
+		val results = Array<Deferred<List<Int>>?>(4) { null }
+		runBlocking {
+			for (i in 0 until 4) {
+				val startIdx = i * 25
+				val endIdx = if (i == 3)
+					101 else startIdx + 25
+				results[i] = async {
+					findOutOfBounds(
+						u101, 10.0, 50.0,
+						startIdx, endIdx
+					)
+				}
+			}
+			assertEquals(25, results[0]!!.await().size)
+			assertEquals(5, results[1]!!.await().size)
+			assertEquals(4, results[2]!!.await().size)
+			assertEquals(26, results[3]!!.await().size)
+		}
 	}
 
 }

--- a/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListFindOutOfBoundsTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListFindOutOfBoundsTest.kt
@@ -110,17 +110,17 @@ class DoubleListFindOutOfBoundsTest {
 
 	@Test
 	fun testU101With20OutOfBoundsEachSide() {
-		val result = findOutOfBounds(
+		val res = findOutOfBounds(
 			u101, 0.0, 60.0,
 		)
-		assertEquals(40, result.size)
+		assertEquals(40, res.size)
 		for (i in 0 until 20)
 			assertEquals(
-				(-20.0 + i), u101[result[i]]
+				(-20.0 + i), u101[res[i]]
 			)
 		for (i in 61 .. 80 )
 			assertEquals(
-				i.toDouble(), u101[result[i - 41]]
+				i.toDouble(), u101[res[i - 41]]
 			)
 	}
 
@@ -136,67 +136,67 @@ class DoubleListFindOutOfBoundsTest {
 
 	@Test
 	fun testStartArg() {
-		val result1 = findOutOfBounds(
+		val res1 = findOutOfBounds(
 			u101, -10.0, 80.0, 9
 		)
-		val result2 = findOutOfBounds(
+		val res2 = findOutOfBounds(
 			u101, -10.0, 80.0, 10
 		)
-		val result3 = findOutOfBounds(
+		val res3 = findOutOfBounds(
 			u101, -10.0, 79.0, 9
 		)
-		assertEquals(listOf(9), result1)
-		assertEquals(0, result2.size)
-		assertEquals(listOf(9, 100), result3)
+		assertEquals(listOf(9), res1)
+		assertEquals(0, res2.size)
+		assertEquals(listOf(9, 100), res3)
 	}
 
 	@Test
 	fun testEndArg() {
-		val result1 = findOutOfBounds(
+		val res1 = findOutOfBounds(
 			u101, -20.0, 79.0, 0, 100
 		)
-		val result2 = findOutOfBounds(
-			u101, -20.0, 79.0, 0, 101
+		val res2 = findOutOfBounds(
+			u101, -20.0, 79.0, 0, 105
 		)
-		val result3 = findOutOfBounds(
+		val res3 = findOutOfBounds(
 			u101, -19.0, 70.0, 0, 92
 		)
-		assertEquals(0, result1.size)
-		assertEquals(100, result2[0])
-		assertEquals(listOf(0, 91), result3)
+		assertEquals(0, res1.size)
+		assertEquals(listOf(100), res2)
+		assertEquals(listOf(0, 91), res3)
 	}
 
 	@Test
 	fun testSublistSearch() {
-		val result1 = findOutOfBounds(
+		val res1 = findOutOfBounds(
 			u101, -10.0, 70.0, 9, 92
 		)
-		val result2 = findOutOfBounds(
+		val res2 = findOutOfBounds(
 			u101, -10.0, 70.0, 10, 92
 		)
-		val result3 = findOutOfBounds(
+		val res3 = findOutOfBounds(
 			u101, -10.0, 70.0, 9, 91
 		)
-		assertEquals(listOf(9, 91), result1)
-		assertEquals(91, result2[0])
-		assertEquals(9, result3[0])
+		assertEquals(listOf(9, 91), res1)
+		assertEquals(91, res2[0])
+		assertEquals(9, res3[0])
 	}
 
 	@Test
 	fun testBadIndexArgs() {
-		val results = Array<List<Int>?>(3) { null }
-		results[0] = findOutOfBounds(
+		val res = Array<List<Int>?>(3) { null }
+		res[0] = findOutOfBounds(
 			u101, -10.0, 70.0, 91, 91
 		)
-		results[1] = findOutOfBounds(
+		res[1] = findOutOfBounds(
 			u101, -10.0, 70.0, 91, 90
 		)
-		results[2] = findOutOfBounds(
+		res[2] = findOutOfBounds(
 			u101, -10.0, 70.0, -1, 91
 		)
 		assertEquals(
 			listOf(0, 0, 0),
-			results.map { it?.size }
+			res.map { it?.size }
 		)
 	}
 
@@ -204,21 +204,21 @@ class DoubleListFindOutOfBoundsTest {
 	fun testSplitSublistSearch() {
 		runBlocking {
 			// Split search into 4 coroutines
-			val results = Array<Deferred<List<Int>>?>(4) { null }
+			val res = Array<Deferred<List<Int>>?>(4) { null }
 			val indexRangePairs = listOf(
 				0 to 24, 25 to 50, 51 to 75, 76 to 100,
 			)
 			for (i in 0 until 4)
-				results[i] = async {
+				res[i] = async {
 					findOutOfBounds(
 						u101, 10.0, 50.0,
 						indexRangePairs[i].first, indexRangePairs[i].second + 1
 					)
 				}
-			assertEquals(25, results[0]!!.await().size)
-			assertEquals(5, results[1]!!.await().size)
-			assertEquals(5, results[2]!!.await().size)
-			assertEquals(25, results[3]!!.await().size)
+			assertEquals(25, res[0]!!.await().size)
+			assertEquals(5, res[1]!!.await().size)
+			assertEquals(5, res[2]!!.await().size)
+			assertEquals(25, res[3]!!.await().size)
 		}
 	}
 

--- a/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListFindOutOfBoundsTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListFindOutOfBoundsTest.kt
@@ -183,6 +183,24 @@ class DoubleListFindOutOfBoundsTest {
 	}
 
 	@Test
+	fun testBadIndexArgs() {
+		val results = Array<List<Int>?>(3) { null }
+		results[0] = findOutOfBounds(
+			u101, -10.0, 70.0, 91, 91
+		)
+		results[1] = findOutOfBounds(
+			u101, -10.0, 70.0, 91, 90
+		)
+		results[2] = findOutOfBounds(
+			u101, -10.0, 70.0, -1, 91
+		)
+		assertEquals(
+			listOf(0, 0, 0),
+			results.map { it?.size }
+		)
+	}
+
+	@Test
 	fun testSplitSublistSearch() {
 		val results = Array<Deferred<List<Int>>?>(4) { null }
 		runBlocking {

--- a/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListTestResources.kt
+++ b/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListTestResources.kt
@@ -16,17 +16,6 @@ object DoubleListTestResources {
             medListFactor * (it + 1)
         }.toMutableList()
 
-    internal const val largeListFactor = 5_000_00_000.500543
-    /** A list with 150_000 elements */
-    internal val largeList: MutableList<Double>
-        get() = Array(150_000) {
-            largeListFactor * (it + 1)
-        }.toMutableList()
-
-    /** A list containing a single element 5.0 */
-    internal val singleItemList: MutableList<Double>
-        get() = mutableListOf(5.0)
-
     /** A list containing the max Double value */
     internal val maxValueList: MutableList<Double>
         get() = Array(5) {

--- a/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListTestResources.kt
+++ b/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListTestResources.kt
@@ -1,5 +1,7 @@
 package mathtools.lists.doubles
 
+/** Provider of Double List data samples for testing
+ * @author DK96-OS : 2022 */
 object DoubleListTestResources {
 
     internal const val smallListFactor = 100.101

--- a/lists/src/test/kotlin/mathtools/lists/ints/IntListFindGreaterThanTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/ints/IntListFindGreaterThanTest.kt
@@ -7,10 +7,19 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 /** Testing the IntList FindGreaterThan function
- * Developed by DK96-OS : 2022 */
+ * @author DK96-OS : 2022 */
 class IntListFindGreaterThanTest {
 
 	private val u101 = toInt(uniform101)
+
+	@Test
+	fun testEmptyList() {
+		assertEquals(
+			0, findGreaterThan(
+				emptyList(), 5
+			).size
+		)
+	}
 
 	@Test
 	fun testSingleItem() {
@@ -27,20 +36,11 @@ class IntListFindGreaterThanTest {
 	}
 
 	@Test
-	fun testEmptyList() {
+	fun testMaxValue() {
 		assertEquals(
-			0, findGreaterThan(
-				emptyList(), 5
-			).size
-		)
-	}
-
-	@Test
-	fun testFindGreaterThanMaxValue() {
-		assertEquals(
-			1, findGreaterThan(
+			listOf(0), findGreaterThan(
 				listOf(Int.MAX_VALUE), 2
-			).size
+			)
 		)
 		// Max Value Limit
 		assertEquals(
@@ -48,6 +48,61 @@ class IntListFindGreaterThanTest {
 				listOf(Int.MAX_VALUE), Int.MAX_VALUE
 			).size
 		)
+	}
+
+	@Test
+	fun testStartArg() {
+		val res = Array<List<Int>?>(4) { null }
+		res[0] = findGreaterThan(
+			u101, 77, 96
+		)
+		res[1] = findGreaterThan(
+			u101, 77, 99
+		)
+		res[2] = findGreaterThan(
+			u101, 77, 120
+		)
+		res[3] = findGreaterThan(
+			u101, 77, -1
+		)
+		assertEquals(listOf(98, 99, 100), res[0])
+		assertEquals(listOf(99, 100), res[1])
+		assertEquals(0, res[2]?.size)
+		assertEquals(0, res[3]?.size)
+	}
+
+	@Test
+	fun testEndArg() {
+		val res = Array<List<Int>?>(4) { null }
+		res[0] = findGreaterThan(
+			u101, -17, 0, 6
+		)
+		res[1] = findGreaterThan(
+			u101, -17, 0, 5
+		)
+		res[2] = findGreaterThan(
+			u101, -17, 0, -1
+		)
+		res[3] = findGreaterThan(
+			u101, 77, 0, 120
+		)
+		assertEquals(listOf(4, 5), res[0])
+		assertEquals(listOf(4), res[1])
+		assertEquals(0, res[2]?.size)
+		assertEquals(listOf(98, 99, 100), res[3])
+	}
+
+	@Test
+	fun testSublistSearch() {
+		val res = Array<List<Int>?>(2) { null }
+		res[0] = findGreaterThan(
+			u101, -17, 4, 6
+		)
+		res[1] = findGreaterThan(
+			u101, 77, 95, 100
+		)
+		assertEquals(listOf(4, 5), res[0])
+		assertEquals(listOf(98, 99), res[1])
 	}
 
 	@Test

--- a/lists/src/test/kotlin/mathtools/lists/ints/IntListFindGreaterThanTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/ints/IntListFindGreaterThanTest.kt
@@ -1,0 +1,72 @@
+package mathtools.lists.ints
+
+import mathtools.lists.IntList.findGreaterThan
+import mathtools.lists.NumberListConversion.toInt
+import mathtools.lists.testdata.ListDataSource.uniform101
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/** Testing the IntList FindGreaterThan function
+ * Developed by DK96-OS : 2022 */
+class IntListFindGreaterThanTest {
+
+	private val u101 = toInt(uniform101)
+
+	@Test
+	fun testSingleItem() {
+		assertEquals(
+			0, findGreaterThan(
+				listOf(5), 5
+			).size
+		)
+		assertEquals(
+			listOf(0), findGreaterThan(
+				listOf(5), 4
+			)
+		)
+	}
+
+	@Test
+	fun testEmptyList() {
+		assertEquals(
+			0, findGreaterThan(
+				emptyList(), 5
+			).size
+		)
+	}
+
+	@Test
+	fun testFindGreaterThanMaxValue() {
+		assertEquals(
+			1, findGreaterThan(
+				listOf(Int.MAX_VALUE), 2
+			).size
+		)
+		// Max Value Limit
+		assertEquals(
+			0, findGreaterThan(
+				listOf(Int.MAX_VALUE), Int.MAX_VALUE
+			).size
+		)
+	}
+
+	@Test
+	fun testBadArguments() {
+		assertEquals(
+			u101.size, findGreaterThan(
+				u101, Int.MIN_VALUE, 0
+			).size
+		)
+		assertEquals(
+			0, findGreaterThan(
+				u101, 5, -1
+			).size
+		)
+		assertEquals(
+			0, findGreaterThan(
+				u101, 5, u101.size
+			).size
+		)
+	}
+
+}

--- a/lists/src/test/kotlin/mathtools/lists/ints/IntListFindLessThanTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/ints/IntListFindLessThanTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 /** Testing the IntList FindLessThan function
- * Developed by DK96-OS : 2022 */
+ * @author DK96-OS : 2022 */
 class IntListFindLessThanTest {
 
 	private val u101 = toInt(uniform101)

--- a/lists/src/test/kotlin/mathtools/lists/ints/IntListFindLessThanTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/ints/IntListFindLessThanTest.kt
@@ -31,7 +31,7 @@ class IntListFindLessThanTest {
 		assertEquals(
 			listOf(0), findLessThan(
 				listOf(5), 6
-			).size
+			)
 		)
 	}
 
@@ -41,6 +41,75 @@ class IntListFindLessThanTest {
 			0, findLessThan(
 				listOf(Int.MAX_VALUE), Int.MAX_VALUE
 			).size
+		)
+		assertEquals(
+			listOf(0), findLessThan(
+				listOf(5), Int.MAX_VALUE
+			)
+		)
+	}
+
+	@Test
+	fun testStartArg() {
+		val res = Array<List<Int>?>(3) { null }
+		res[0] = findLessThan(
+			u101, -17, 1
+		)
+		res[1] = findLessThan(
+			u101, -17, 2
+		)
+		res[2] = findLessThan(
+			u101, -17, -1
+		)
+		assertEquals(listOf(1, 2), res[0])
+		assertEquals(listOf(2), res[1])
+		assertEquals(0, res[2]?.size)
+	}
+
+	@Test
+	fun testEndArg() {
+		val res = Array<List<Int>?>(3) { null }
+		res[0] = findLessThan(
+			u101, -17, 0, 6
+		)
+		res[1] = findLessThan(
+			u101, -17, 0, 2
+		)
+		res[2] = findLessThan(
+			u101, -17, 0, -1
+		)
+		assertEquals(listOf(0, 1, 2), res[0])
+		assertEquals(listOf(0, 1), res[1])
+		assertEquals(0, res[2]?.size)
+	}
+
+	@Test
+	fun testSublistSearch() {
+		val res = Array<List<Int>?>(2) { null }
+		res[0] = findLessThan(
+			u101, -17, 1, 5
+		)
+		res[1] = findLessThan(
+			u101.reversed(), -17, 95, 100
+		)
+		assertEquals(listOf(1, 2), res[0])
+		assertEquals(listOf(98, 99), res[1])
+	}
+	@Test
+	fun testBadIndexArgs() {
+		val res = Array<List<Int>?>(3) { null }
+		res[0] = findLessThan(
+			u101, -17, 99, 99
+		)
+		res[1] = findLessThan(
+			u101, -17, 99, 98
+		)
+		res[2] = findLessThan(
+			u101, -17, -1, 98
+		)
+		assertEquals(
+			listOf(0, 0, 0),
+			res.map { it?.size }
 		)
 	}
 

--- a/lists/src/test/kotlin/mathtools/lists/ints/IntListFindLessThanTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/ints/IntListFindLessThanTest.kt
@@ -1,0 +1,47 @@
+package mathtools.lists.ints
+
+import mathtools.lists.IntList.findLessThan
+import mathtools.lists.NumberListConversion.toInt
+import mathtools.lists.testdata.ListDataSource.uniform101
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/** Testing the IntList FindLessThan function
+ * Developed by DK96-OS : 2022 */
+class IntListFindLessThanTest {
+
+	private val u101 = toInt(uniform101)
+
+	@Test
+	fun testEmptyList() {
+		assertEquals(
+			0, findLessThan(
+				emptyList(), 5
+			).size
+		)
+	}
+
+	@Test
+	fun testSingleItem() {
+		assertEquals(
+			0, findLessThan(
+				listOf(5), 5
+			).size
+		)
+		assertEquals(
+			listOf(0), findLessThan(
+				listOf(5), 6
+			).size
+		)
+	}
+
+	@Test
+	fun testMaxValue() {
+		assertEquals(
+			0, findLessThan(
+				listOf(Int.MAX_VALUE), Int.MAX_VALUE
+			).size
+		)
+	}
+
+}

--- a/lists/src/test/kotlin/mathtools/lists/ints/IntListFindOutOfRangeTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/ints/IntListFindOutOfRangeTest.kt
@@ -1,0 +1,143 @@
+package mathtools.lists.ints
+
+import mathtools.lists.IntList.findOutOfRange
+import mathtools.lists.NumberListConversion.toInt
+import mathtools.lists.testdata.ListDataSource.uniform101
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class IntListFindOutOfRangeTest {
+
+	private val u101 = toInt(uniform101)
+
+	@Test
+	fun testEmptyList() {
+		assertEquals(
+			0, findOutOfRange(
+				emptyList(), 1 .. 20
+			).size
+		)
+	}
+
+	@Test
+	fun testSingleItemList() {
+		assertEquals(
+			0, findOutOfRange(
+				listOf(5), 0 .. 9
+			).size
+		)
+		assertEquals(
+			listOf(0), findOutOfRange(
+				listOf(5), -6 .. 4
+			)
+		)
+		assertEquals(
+			listOf(0), findOutOfRange(
+				listOf(6), 7 .. Int.MAX_VALUE
+			)
+		)
+	}
+
+	@Test
+	fun testBadArguments() {
+		// Reversed Bounds
+		assertEquals(
+			0, findOutOfRange(
+				u101, 60 .. 40
+			).size
+		)
+	}
+
+	@Test
+	fun testEqualBounds() {
+		// No elements equal to bounds
+		assertEquals(
+			u101.size,
+			findOutOfRange(
+				u101, 121 .. 121
+			).size
+		)
+		// One Element is equal to bounds
+		assertEquals(
+			u101.size - 1,
+			findOutOfRange(
+				u101, 30 .. 30
+			).size
+		)
+	}
+
+	@Test
+	fun testU101With20EachSide() {
+		val result = findOutOfRange(
+			u101, 0 .. 60,
+		)
+		assertEquals(40, result.size)
+		for (i in 0 until 20)
+			assertEquals(
+				(-20 + i), u101[result[i]]
+			)
+		for (i in 61 .. 80 )
+			assertEquals(
+				i, u101[result[i - 41]]
+			)
+	}
+
+	@Test
+	fun testU101AllOutOfRange() {
+		assertEquals(
+			u101.indices.toList(),
+			findOutOfRange(
+				u101, -200 .. -100
+			)
+		)
+	}
+
+	@Test
+	fun testStartArg() {
+		val result1 = findOutOfRange(
+			u101, -10 .. 80, 9
+		)
+		val result2 = findOutOfRange(
+			u101, -10 .. 80, 10
+		)
+		val result3 = findOutOfRange(
+			u101, -10 .. 79, 9
+		)
+		assertEquals(listOf(9), result1)
+		assertEquals(0, result2.size)
+		assertEquals(listOf(9, 100), result3)
+	}
+
+	@Test
+	fun testEndArg() {
+		val result1 = findOutOfRange(
+			u101, -20 .. 79, 0, 100
+		)
+		val result2 = findOutOfRange(
+			u101, -20 .. 79, 0, 101
+		)
+		val result3 = findOutOfRange(
+			u101, -19 .. 70, 0, 92
+		)
+		assertEquals(0, result1.size)
+		assertEquals(100, result2[0])
+		assertEquals(listOf(0, 91), result3)
+	}
+
+	@Test
+	fun testSublistSearch() {
+		val result1 = findOutOfRange(
+			u101, -10 .. 70, 9, 92
+		)
+		val result2 = findOutOfRange(
+			u101, -10 .. 70, 10, 92
+		)
+		val result3 = findOutOfRange(
+			u101, -10 .. 70, 9, 91
+		)
+		assertEquals(listOf(9, 91), result1)
+		assertEquals(91, result2[0])
+		assertEquals(9, result3[0])
+	}
+
+}

--- a/lists/src/test/kotlin/mathtools/lists/ints/IntListFindOutOfRangeTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/ints/IntListFindOutOfRangeTest.kt
@@ -6,6 +6,8 @@ import mathtools.lists.testdata.ListDataSource.uniform101
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
+/** Testing the IntList FindOutOfRange function
+ * @author DK96-OS : 2022 */
 class IntListFindOutOfRangeTest {
 
 	private val u101 = toInt(uniform101)

--- a/lists/src/test/kotlin/mathtools/lists/longs/LongListFindGreaterThanTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/longs/LongListFindGreaterThanTest.kt
@@ -65,27 +65,26 @@ class LongListFindGreaterThanTest {
 
 	@Test
 	fun testEndArg() {
-		val res = Array<List<Int>?>(2) { null }
+		val res = Array<List<Int>?>(3) { null }
 		res[0] = findGreaterThan(
 			u101, 78, 0, 105
 		)
 		res[1] = findGreaterThan(
 			u101, 78, 0, 100
 		)
+		res[2] = findGreaterThan(
+			u101, 78, 0, -1
+		)
 		assertEquals(listOf(99, 100), res[0])
 		assertEquals(listOf(99), res[1])
+		assertEquals(0, res[2]?.size)
 	}
 
 	@Test
-	fun testBadArguments() {
+	fun testBadArgs() {
 		assertEquals(
 			u101.size, findGreaterThan(
 				u101, Long.MIN_VALUE, 0
-			).size
-		)
-		assertEquals(
-			0, findGreaterThan(
-				u101, 5L, -1
 			).size
 		)
 		assertEquals(

--- a/lists/src/test/kotlin/mathtools/lists/longs/LongListFindGreaterThanTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/longs/LongListFindGreaterThanTest.kt
@@ -7,12 +7,20 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 /** Testing the GreaterThan function on Long Lists
- * Developed by DK96-OS : 2022 */
+ * @author DK96-OS : 2022 */
 class LongListFindGreaterThanTest {
 
 	private val u101 = toLong(uniform101)
 
-	/** Greater Than works on single item and empty lists */
+	@Test
+	fun testEmptyList() {
+		assertEquals(
+			0, findGreaterThan(
+				emptyList(), 5L
+			).size
+		)
+	}
+
 	@Test
 	fun testSingleItem() {
 		assertEquals(
@@ -21,18 +29,9 @@ class LongListFindGreaterThanTest {
 			).size
 		)
 		assertEquals(
-			1, findGreaterThan(
+			listOf(0), findGreaterThan(
 				listOf(5L), 4L
-			).size
-		)
-	}
-
-	@Test
-	fun testEmptyList() {
-		assertEquals(
-			0, findGreaterThan(
-				emptyList(), 5L
-			).size
+			)
 		)
 	}
 
@@ -49,6 +48,32 @@ class LongListFindGreaterThanTest {
 				listOf(Long.MAX_VALUE), Long.MAX_VALUE
 			).size
 		)
+	}
+
+	@Test
+	fun testStartArg() {
+		val res = Array<List<Int>?>(2) { null }
+		res[0] = findGreaterThan(
+			u101, 78, 90
+		)
+		res[1] = findGreaterThan(
+			u101, 78, 100
+		)
+		assertEquals(listOf(99, 100), res[0])
+		assertEquals(listOf(100), res[1])
+	}
+
+	@Test
+	fun testEndArg() {
+		val res = Array<List<Int>?>(2) { null }
+		res[0] = findGreaterThan(
+			u101, 78, 0, 105
+		)
+		res[1] = findGreaterThan(
+			u101, 78, 0, 100
+		)
+		assertEquals(listOf(99, 100), res[0])
+		assertEquals(listOf(99), res[1])
 	}
 
 	@Test

--- a/lists/src/test/kotlin/mathtools/lists/longs/LongListFindGreaterThanTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/longs/LongListFindGreaterThanTest.kt
@@ -8,13 +8,13 @@ import org.junit.jupiter.api.Test
 
 /** Testing the GreaterThan function on Long Lists
  * Developed by DK96-OS : 2022 */
-class LongListGreaterThanTest {
+class LongListFindGreaterThanTest {
 
 	private val u101 = toLong(uniform101)
 
 	/** Greater Than works on single item and empty lists */
 	@Test
-	fun testFindGreaterThanSingleItem() {
+	fun testSingleItem() {
 		assertEquals(
 			0, findGreaterThan(
 				listOf(5L), 5L
@@ -37,11 +37,11 @@ class LongListGreaterThanTest {
 	}
 
 	@Test
-	fun testFindGreaterThanMaxValue() {
+	fun testMaxValue() {
 		assertEquals(
-			1, findGreaterThan(
+			listOf(0), findGreaterThan(
 				listOf(Long.MAX_VALUE), 2
-			).size
+			)
 		)
 		// Max Value Limit
 		assertEquals(

--- a/lists/src/test/kotlin/mathtools/lists/longs/LongListFindLessThanTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/longs/LongListFindLessThanTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 /** Testing the IntList FindLessThan function
- * Developed by DK96-OS : 2022 */
+ * @author DK96-OS : 2022 */
 class LongListFindLessThanTest {
 
 	private val u101 = toLong(uniform101)
@@ -31,7 +31,7 @@ class LongListFindLessThanTest {
 		assertEquals(
 			listOf(0), findLessThan(
 				listOf(5L), 6L
-			).size
+			)
 		)
 	}
 
@@ -41,6 +41,75 @@ class LongListFindLessThanTest {
 			0, findLessThan(
 				listOf(Long.MAX_VALUE), Long.MAX_VALUE
 			).size
+		)
+		assertEquals(
+			listOf(0), findLessThan(
+				listOf(5L), Long.MAX_VALUE
+			)
+		)
+	}
+
+	@Test
+	fun testStartArg() {
+		val res = Array<List<Int>?>(3) { null }
+		res[0] = findLessThan(
+			u101, -17, 1
+		)
+		res[1] = findLessThan(
+			u101, -17, 2
+		)
+		res[2] = findLessThan(
+			u101, -17, -1
+		)
+		assertEquals(listOf(1, 2), res[0])
+		assertEquals(listOf(2), res[1])
+		assertEquals(0, res[2]?.size)
+	}
+
+	@Test
+	fun testEndArg() {
+		val res = Array<List<Int>?>(3) { null }
+		res[0] = findLessThan(
+			u101, -17, 0, 6
+		)
+		res[1] = findLessThan(
+			u101, -17, 0, 2
+		)
+		res[2] = findLessThan(
+			u101, -17, 0, -1
+		)
+		assertEquals(listOf(0, 1, 2), res[0])
+		assertEquals(listOf(0, 1), res[1])
+		assertEquals(0, res[2]?.size)
+	}
+
+	@Test
+	fun testSublistSearch() {
+		val res = Array<List<Int>?>(2) { null }
+		res[0] = findLessThan(
+			u101, -17, 1, 5
+		)
+		res[1] = findLessThan(
+			u101.reversed(), -17, 95, 100
+		)
+		assertEquals(listOf(1, 2), res[0])
+		assertEquals(listOf(98, 99), res[1])
+	}
+	@Test
+	fun testBadIndexArgs() {
+		val res = Array<List<Int>?>(3) { null }
+		res[0] = findLessThan(
+			u101, -17, 99, 99
+		)
+		res[1] = findLessThan(
+			u101, -17, 99, 98
+		)
+		res[2] = findLessThan(
+			u101, -17, -1, 98
+		)
+		assertEquals(
+			listOf(0, 0, 0),
+			res.map { it?.size }
 		)
 	}
 

--- a/lists/src/test/kotlin/mathtools/lists/longs/LongListFindLessThanTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/longs/LongListFindLessThanTest.kt
@@ -95,6 +95,7 @@ class LongListFindLessThanTest {
 		assertEquals(listOf(1, 2), res[0])
 		assertEquals(listOf(98, 99), res[1])
 	}
+
 	@Test
 	fun testBadIndexArgs() {
 		val res = Array<List<Int>?>(3) { null }

--- a/lists/src/test/kotlin/mathtools/lists/longs/LongListFindLessThanTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/longs/LongListFindLessThanTest.kt
@@ -1,0 +1,47 @@
+package mathtools.lists.longs
+
+import mathtools.lists.LongList.findLessThan
+import mathtools.lists.NumberListConversion.toLong
+import mathtools.lists.testdata.ListDataSource.uniform101
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/** Testing the IntList FindLessThan function
+ * Developed by DK96-OS : 2022 */
+class LongListFindLessThanTest {
+
+	private val u101 = toLong(uniform101)
+
+	@Test
+	fun testEmptyList() {
+		assertEquals(
+			0, findLessThan(
+				emptyList(), 5L
+			).size
+		)
+	}
+
+	@Test
+	fun testSingleItem() {
+		assertEquals(
+			0, findLessThan(
+				listOf(5L), 5L
+			).size
+		)
+		assertEquals(
+			listOf(0), findLessThan(
+				listOf(5L), 6L
+			).size
+		)
+	}
+
+	@Test
+	fun testMaxValue() {
+		assertEquals(
+			0, findLessThan(
+				listOf(Long.MAX_VALUE), Long.MAX_VALUE
+			).size
+		)
+	}
+
+}

--- a/lists/src/test/kotlin/mathtools/lists/longs/LongListFindOutOfRangeTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/longs/LongListFindOutOfRangeTest.kt
@@ -9,7 +9,8 @@ import mathtools.lists.testdata.ListDataSource.uniform101
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
-/** Testing DoubleList's findOutOfRange function */
+/** Testing DoubleList's findOutOfRange function
+ * @author DK96-OS : 2022 */
 class LongListFindOutOfRangeTest {
 
 	private val u101 = toLong(uniform101)

--- a/lists/src/test/kotlin/mathtools/lists/longs/LongListFindOutOfRangeTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/longs/LongListFindOutOfRangeTest.kt
@@ -119,7 +119,7 @@ class LongListFindOutOfRangeTest {
 			u101, -20 .. 79L, 0, 100
 		)
 		val result2 = findOutOfRange(
-			u101, -20 ..79L, 0, 101
+			u101, -20 ..79L, 0, 105
 		)
 		val result3 = findOutOfRange(
 			u101, -19 .. 70L, 0, 92
@@ -131,39 +131,40 @@ class LongListFindOutOfRangeTest {
 
 	@Test
 	fun testSublistSearch() {
-		val result1 = findOutOfRange(
+		val res = Array<List<Int>?>(3) { null }
+		res[0] = findOutOfRange(
 			u101, -10 .. 70L, 9, 92
 		)
-		val result2 = findOutOfRange(
+		res[1] = findOutOfRange(
 			u101, -10 .. 70L, 10, 92
 		)
-		val result3 = findOutOfRange(
+		res[2] = findOutOfRange(
 			u101, -10 .. 70L, 9, 91
 		)
-		assertEquals(listOf(9, 91), result1)
-		assertEquals(91, result2[0])
-		assertEquals(9, result3[0])
+		assertEquals(listOf(9, 91), res[0])
+		assertEquals(listOf(91), res[1])
+		assertEquals(listOf(9), res[2])
 	}
 
 	@Test
 	fun testSplitSublistSearch() {
-		val results = Array<Deferred<List<Int>>?>(4) { null }
 		runBlocking {
-			for (i in 0 until 4) {
-				val startIdx = i * 25
-				val endIdx = if (i == 3)
-					101 else startIdx + 25
+			val results = Array<Deferred<List<Int>>?>(4) { null }
+			val indexRangePairs = listOf(
+				0 to 24, 25 to 50, 51 to 74, 75 to 101
+			)
+			for (i in 0 until 4)
 				results[i] = async {
 					findOutOfRange(
 						u101, 10 .. 50L,
-						startIdx, endIdx
+						indexRangePairs[i].first,
+						indexRangePairs[i].second,
 					)
 				}
-			}
 			assertEquals(25, results[0]!!.await().size)
 			assertEquals(5, results[1]!!.await().size)
-			assertEquals(4, results[2]!!.await().size)
-			assertEquals(26, results[3]!!.await().size)
+			assertEquals(5, results[2]!!.await().size)
+			assertEquals(25, results[3]!!.await().size)
 		}
 	}
 

--- a/lists/src/test/kotlin/mathtools/lists/longs/LongListFindOutOfRangeTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/longs/LongListFindOutOfRangeTest.kt
@@ -9,7 +9,7 @@ import mathtools.lists.testdata.ListDataSource.uniform101
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
-/** Testing DoubleList's findOutOfRange function
+/** Testing LongList findOutOfRange function
  * @author DK96-OS : 2022 */
 class LongListFindOutOfRangeTest {
 

--- a/lists/src/test/kotlin/mathtools/lists/longs/LongListFindOutOfRangeTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/longs/LongListFindOutOfRangeTest.kt
@@ -1,5 +1,8 @@
 package mathtools.lists.longs
 
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
 import mathtools.lists.LongList.findOutOfRange
 import mathtools.lists.NumberListConversion.toLong
 import mathtools.lists.testdata.ListDataSource.uniform101
@@ -91,6 +94,76 @@ class LongListFindOutOfRangeTest {
 				u101, -200L .. -100
 			)
 		)
+	}
+
+	@Test
+	fun testStartArg() {
+		val result1 = findOutOfRange(
+			u101, -10 .. 80L, 9
+		)
+		val result2 = findOutOfRange(
+			u101, -10 .. 80L, 10
+		)
+		val result3 = findOutOfRange(
+			u101, -10 .. 79L, 9
+		)
+		assertEquals(listOf(9), result1)
+		assertEquals(0, result2.size)
+		assertEquals(listOf(9, 100), result3)
+	}
+
+	@Test
+	fun testEndArg() {
+		val result1 = findOutOfRange(
+			u101, -20 .. 79L, 0, 100
+		)
+		val result2 = findOutOfRange(
+			u101, -20 ..79L, 0, 101
+		)
+		val result3 = findOutOfRange(
+			u101, -19 .. 70L, 0, 92
+		)
+		assertEquals(0, result1.size)
+		assertEquals(100, result2[0])
+		assertEquals(listOf(0, 91), result3)
+	}
+
+	@Test
+	fun testSublistSearch() {
+		val result1 = findOutOfRange(
+			u101, -10 .. 70L, 9, 92
+		)
+		val result2 = findOutOfRange(
+			u101, -10 .. 70L, 10, 92
+		)
+		val result3 = findOutOfRange(
+			u101, -10 .. 70L, 9, 91
+		)
+		assertEquals(listOf(9, 91), result1)
+		assertEquals(91, result2[0])
+		assertEquals(9, result3[0])
+	}
+
+	@Test
+	fun testSplitSublistSearch() {
+		val results = Array<Deferred<List<Int>>?>(4) { null }
+		runBlocking {
+			for (i in 0 until 4) {
+				val startIdx = i * 25
+				val endIdx = if (i == 3)
+					101 else startIdx + 25
+				results[i] = async {
+					findOutOfRange(
+						u101, 10 .. 50L,
+						startIdx, endIdx
+					)
+				}
+			}
+			assertEquals(25, results[0]!!.await().size)
+			assertEquals(5, results[1]!!.await().size)
+			assertEquals(4, results[2]!!.await().size)
+			assertEquals(26, results[3]!!.await().size)
+		}
 	}
 
 }

--- a/lists/src/test/kotlin/mathtools/lists/longs/LongListFindOutOfRangeTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/longs/LongListFindOutOfRangeTest.kt
@@ -151,14 +151,14 @@ class LongListFindOutOfRangeTest {
 		runBlocking {
 			val results = Array<Deferred<List<Int>>?>(4) { null }
 			val indexRangePairs = listOf(
-				0 to 24, 25 to 50, 51 to 74, 75 to 101
+				0 to 24, 25 to 50, 51 to 75, 76 to 101
 			)
 			for (i in 0 until 4)
 				results[i] = async {
 					findOutOfRange(
 						u101, 10 .. 50L,
 						indexRangePairs[i].first,
-						indexRangePairs[i].second,
+						indexRangePairs[i].second + 1,
 					)
 				}
 			assertEquals(25, results[0]!!.await().size)


### PR DESCRIPTION
Add an end index argument to the list searching functions.

A default value is provided for the argument - no change in behavior when equals to list size (or greater - this case is handled so that no index out of bounds is thrown).

Resolves #34 

Additionally, the IntList functions have no tests. These will be added in this PR.