### PR TITLE
Prime Numbers Cache Static Properties

### DIFF
--- a/numbers/src/main/kotlin/mathtools/numbers/primes/BytePrimeCache.kt
+++ b/numbers/src/main/kotlin/mathtools/numbers/primes/BytePrimeCache.kt
@@ -1,9 +1,9 @@
 package mathtools.numbers.primes
 
-/** A Lookup Table for Prime Numbers within the UByte Range, up to 251
-   *  Developed by DK96-OS : 2021 */
+/** An array-based cache for Prime Numbers in the 8-bit integer range
+ * @author DK96-OS : 2021 */
 open class BytePrimeCache : PrimeCacheBase(
-	maxIndex = MAX_INDEX,  // This is the Index of the prime number 251
+	maxIndex = MAX_INDEX,
 	maxValue = MAX_PRIME,
 ) {
 	private var byteArray: ByteArray? = null
@@ -25,7 +25,7 @@ open class BytePrimeCache : PrimeCacheBase(
                 if (raw > 0) raw else raw + 256
             } else {
                 val queueIndex = arrayIndex - arraySize
-                if (queueIndex < queueSize) byteQueue[queueIndex].toInt()
+                if (queueIndex < byteQueue.size) byteQueue[queueIndex].toInt()
                 else if (extendCache(idx)) getPrime(idx)
                 else
                     throw IllegalStateException("Could not get prime at: $idx")
@@ -42,7 +42,7 @@ open class BytePrimeCache : PrimeCacheBase(
 	: Boolean = if (toIndex in indexRange) {
 		var primesRequired = toIndex - highestCachedIndex()
 		if (primesRequired <= 0) false
-		else if (queueSize + primesRequired > 8)
+		else if (byteQueue.size + primesRequired > 8)
 		    consolidate(primesRequired) > 0
 		else {		// Add to queue
 			var prevPrime = getPrime(highestCachedIndex())
@@ -61,7 +61,7 @@ open class BytePrimeCache : PrimeCacheBase(
 
 	override fun consolidate(add: Int): Int {
 		if (add <= 0) throw IllegalArgumentException()
-		val prevSize = arraySize + queueSize
+		val prevSize = arraySize + byteQueue.size
 		if (prevSize + add > indexRange.last + 1) return -1
 		val oldArray = byteArray
 		var prev: Int = getPrime(highestCachedIndex())

--- a/numbers/src/main/kotlin/mathtools/numbers/primes/BytePrimeCache.kt
+++ b/numbers/src/main/kotlin/mathtools/numbers/primes/BytePrimeCache.kt
@@ -3,8 +3,8 @@ package mathtools.numbers.primes
 /** A Lookup Table for Prime Numbers within the UByte Range, up to 251
    *  Developed by DK96-OS : 2021 */
 open class BytePrimeCache : PrimeCacheBase(
-	maxIndex = 53,  // This is the Index of the prime number 251
-	maxValue = UByte.MAX_VALUE.toInt(),
+	maxIndex = MAX_INDEX,  // This is the Index of the prime number 251
+	maxValue = MAX_PRIME,
 ) {
 	private var byteArray: ByteArray? = null
 	private val byteQueue = ArrayList<UByte>(8)
@@ -13,7 +13,7 @@ open class BytePrimeCache : PrimeCacheBase(
 	internal val queueSize: Int get() = byteQueue.size
 
     override fun highestCachedIndex()
-	: Int = 15 + (byteArray?.size ?: 0) + byteQueue.size
+		: Int = 15 + (byteArray?.size ?: 0) + byteQueue.size
 
     override fun getPrime(idx: Int): Int = when {
         idx < 16 -> initArray[idx].toInt()
@@ -85,4 +85,11 @@ open class BytePrimeCache : PrimeCacheBase(
         byteQueue.clear()
         byteArray = null
     }
+
+	companion object {
+		/** The largest index that can be stored */
+		const val MAX_INDEX: Int = 53
+		/** The largest prime value that can be stored */
+		const val MAX_PRIME: Int = 251
+	}
 }

--- a/numbers/src/main/kotlin/mathtools/numbers/primes/PrimeCacheBase.kt
+++ b/numbers/src/main/kotlin/mathtools/numbers/primes/PrimeCacheBase.kt
@@ -89,7 +89,7 @@ abstract class PrimeCacheBase(
     /** Find the next prime using the given number as a starting point
       * @param testNum The first number to test for prime status */
     internal fun findPrime(
-	    testNum: Int
+	    testNum: Int,
     ) : Int? {
 	    if (testNum <= 0) return null
         for (n in testNum .. maxValue step 2) {

--- a/numbers/src/main/kotlin/mathtools/numbers/primes/ShortPrimeCache.kt
+++ b/numbers/src/main/kotlin/mathtools/numbers/primes/ShortPrimeCache.kt
@@ -1,7 +1,7 @@
 package mathtools.numbers.primes
 
-/** A cache for small prime numbers, within Short range
-   *  Developed by DK96-OS : 2021 */
+/** An array-based cache for Prime Numbers in the 16-bit integer range
+ * @author DK96-OS : 2021 */
 open class ShortPrimeCache : PrimeCacheBase(
 	maxIndex = MAX_INDEX,
 	maxValue = MAX_PRIME,

--- a/numbers/src/main/kotlin/mathtools/numbers/primes/ShortPrimeCache.kt
+++ b/numbers/src/main/kotlin/mathtools/numbers/primes/ShortPrimeCache.kt
@@ -89,8 +89,8 @@ open class ShortPrimeCache : PrimeCacheBase(
 
 	companion object {
 		/** The largest index that can be stored */
-		const val MAX_INDEX: Int = 3020
+		const val MAX_INDEX: Int = 3511
 		/** The largest prime value that can be stored */
-		const val MAX_PRIME: Int = Short.MAX_VALUE.toInt()
+		const val MAX_PRIME: Int = 32749
 	}
 }

--- a/numbers/src/main/kotlin/mathtools/numbers/primes/ShortPrimeCache.kt
+++ b/numbers/src/main/kotlin/mathtools/numbers/primes/ShortPrimeCache.kt
@@ -3,15 +3,16 @@ package mathtools.numbers.primes
 /** A cache for small prime numbers, within Short range
    *  Developed by DK96-OS : 2021 */
 open class ShortPrimeCache : PrimeCacheBase(
-	maxIndex = 3020, 
-	maxValue = Short.MAX_VALUE.toInt(),
+	maxIndex = MAX_INDEX,
+	maxValue = MAX_PRIME,
 ) {
 	/** Rely on BytePrimeCache for smallest primes */
 	private val byteCache = BytePrimeCache()
 	
 	/** The range of indexed prime numbers serviced by this cache
 		*  note: maximum index must be less than the index of 32767.  */
-	val shortIndexRange: IntRange = byteCache.maxIndex + 1 .. maxIndex
+	internal val shortIndexRange
+		: IntRange = BytePrimeCache.MAX_INDEX + 1 .. maxIndex
 
 	/** Storage for short primes */
 	private var shortArray: ShortArray = shortArrayOf(
@@ -23,7 +24,7 @@ open class ShortPrimeCache : PrimeCacheBase(
 	private val queueSize: Int get() = shortQueue.size
 
 	override fun highestCachedIndex()
-	: Int = byteCache.maxIndex + shortArray.size + shortQueue.size
+		: Int = BytePrimeCache.MAX_INDEX + shortArray.size + shortQueue.size
 
 	override fun getPrime(idx: Int): Int {
 		val shortIndex = idx - shortIndexRange.first
@@ -84,5 +85,12 @@ open class ShortPrimeCache : PrimeCacheBase(
 		    257, 263, 269, 271, 277, 281, 283, 293,
 		)
 		byteCache.clear()
+	}
+
+	companion object {
+		/** The largest index that can be stored */
+		const val MAX_INDEX: Int = 3020
+		/** The largest prime value that can be stored */
+		const val MAX_PRIME: Int = Short.MAX_VALUE.toInt()
 	}
 }

--- a/numbers/src/test/kotlin/mathtools/numbers/primes/ShortPrimeCacheTest.kt
+++ b/numbers/src/test/kotlin/mathtools/numbers/primes/ShortPrimeCacheTest.kt
@@ -50,6 +50,46 @@ class ShortPrimeCacheTest {
 		for (i in 0 until primeList.size step rate)
 			assertEquals(primeList[i], cache.getPrime(i))
 	}
+
+	@Test
+	fun testSpecificPrimes() {
+		val cache = ShortPrimeCache()
+		assertEquals(547, cache.getPrime(100))
+		assertEquals(661, cache.getPrime(120))
+		assertEquals(811, cache.getPrime(140))
+		assertEquals(947, cache.getPrime(160))
+		assertEquals(1087, cache.getPrime(180))
+		assertEquals(1229, cache.getPrime(200))
+		assertEquals(1993, cache.getPrime(300))
+		assertEquals(2131, cache.getPrime(320))
+		assertEquals(2293, cache.getPrime(340))
+		assertEquals(2437, cache.getPrime(360))
+		assertEquals(2621, cache.getPrime(380))
+		assertEquals(2749, cache.getPrime(400))
+		assertEquals(5801, cache.getPrime(760))
+		assertEquals(7001, cache.getPrime(900))
+		assertEquals(7211, cache.getPrime(920))
+		assertEquals(7727, cache.getPrime(980))
+	}
+
+	@Test
+	fun testShort() {
+		println("Short: ${Short.MAX_VALUE}")
+	}
+
+	@Test
+	fun testMaxIndex() {
+		val cache = ShortPrimeCache()
+		val testIndices = mutableListOf(
+			1000, 2000, 3000, 3090, 3490,
+			3510, 3511
+		)
+		for (i in testIndices) {
+			val prime = cache.getPrime(i)
+			println("Query($i) => $prime")
+		}
+	}
+
 /*
 	@Test fun testCacheExpansionSlow() {
 		val cache = ShortPrimeCache()


### PR DESCRIPTION
Add key static properties to the Prime Number caches.
- Max Index
- Max Value

These static properties will enable users to dynamically choose the appropriate size of Cache (Byte or Short) without instantiating a cache object.