### PR TITLE
Strict NumberList Conversions

### DIFF
--- a/lists/src/main/java/mathtools/lists/BigIntSumBuffer.java
+++ b/lists/src/main/java/mathtools/lists/BigIntSumBuffer.java
@@ -97,4 +97,12 @@ public final class BigIntSumBuffer {
         }
     }
 
+    /** Set the long buffer value - for testing purposes
+     * @param number The number to set the buffer value to */
+    void setLongBuffer(
+            final long number
+    ) {
+        mBuffer = number;
+    }
+
 }

--- a/lists/src/main/java/mathtools/lists/BigIntSumBuffer.java
+++ b/lists/src/main/java/mathtools/lists/BigIntSumBuffer.java
@@ -1,0 +1,98 @@
+package mathtools.lists;
+
+import java.math.BigInteger;
+
+/** A BigInteger sum data structure
+ *  Tries to add primitive number types where possible
+ * @author DK96-OS : 2022 */
+public final class BigIntSumBuffer {
+
+    /** The limit for when a long will be added directly to BigInteger */
+    public static final long longLimit = Long.MAX_VALUE / 2;
+    public static final long longLimitNegative = -longLimit;
+
+    /** The integer limit is much higher */
+    public static final long intLimit = Long.MAX_VALUE - Integer.MAX_VALUE;
+    public static final long intLimitNegative = -intLimit;
+
+    /** The BigInteger part of the sum */
+    private BigInteger mSum = BigInteger.ZERO;
+
+    /** The primitive number type part of the sum */
+    private long mBuffer = 0;
+
+    /** Obtain the current sum
+     * @return A BigInteger containing the sum of all numbers added */
+    public BigInteger getSum() {
+        if (mBuffer != 0L)
+            mSum = mSum.add(BigInteger.valueOf(mBuffer));
+        return mSum;
+    }
+
+    /** Add a 64-bit Integer to the sum
+     * @param number The Long to add to the sum */
+    public void add(
+            final long number
+    ) {
+        if (number > 0) {
+            if (number < longLimit) {
+                mBuffer += number;
+                if (mBuffer > longLimit) {
+                    mSum = mSum.add(BigInteger.valueOf(mBuffer));
+                    mBuffer = 0;
+                }
+            } else {
+                // number is large enough to add directly
+                mSum = mSum.add(BigInteger.valueOf(number));
+            }
+        } else if (number < 0) {
+            // If number is above the negative limit
+            if (number > longLimitNegative) {
+                mBuffer += number;
+                // check if limit is exceeded
+                if (mBuffer < longLimitNegative) {
+                    mSum = mSum.add(BigInteger.valueOf(mBuffer));
+                    mBuffer = 0;
+                }
+            } else
+                mSum = mSum.add(BigInteger.valueOf(number));
+        }
+    }
+
+    /** Add a 32-bit integer to the sum
+     * @param number The Integer to add to the sum */
+    public void add(
+            final int number
+    ) {
+        if (number > 0) {
+            // When safe to add
+            if (mBuffer < intLimit) mBuffer += number;
+            // check addition before adding to sum
+            else {
+                final long checkedAdd = mBuffer + number;
+                if (checkedAdd > mBuffer) { // success
+                    mSum = mSum.add(BigInteger.valueOf(checkedAdd));
+                    mBuffer = 0;
+                } else {    // overflow
+                    mSum = mSum.add(BigInteger.valueOf(mBuffer));
+                    mBuffer = number;
+                }
+            }
+        } else if (number < 0) {
+            // When safe to add
+            if (mBuffer > intLimitNegative) mBuffer += number;
+            // check addition before adding to sum
+            else {
+                final long checkedAdd = mBuffer + number;
+                if (checkedAdd < mBuffer) { // success
+                    mSum = mSum.add(BigInteger.valueOf(checkedAdd));
+                    mBuffer = 0;
+                } else {    // overflow
+                    mSum = mSum.add(BigInteger.valueOf(mBuffer));
+                    mBuffer = number;
+                }
+            }
+        }
+    }
+
+}

--- a/lists/src/main/java/mathtools/lists/BigIntSumBuffer.java
+++ b/lists/src/main/java/mathtools/lists/BigIntSumBuffer.java
@@ -9,23 +9,25 @@ public final class BigIntSumBuffer {
 
     /** The limit for when a long will be added directly to BigInteger */
     public static final long longLimit = Long.MAX_VALUE / 2;
-    public static final long longLimitNegative = -longLimit;
+    public static final long longLimitNegative = Long.MIN_VALUE / 2;
 
     /** The integer limit is much higher */
     public static final long intLimit = Long.MAX_VALUE - Integer.MAX_VALUE;
-    public static final long intLimitNegative = -intLimit;
+    public static final long intLimitNegative = Long.MIN_VALUE - Integer.MIN_VALUE;
 
     /** The BigInteger part of the sum */
     private BigInteger mSum = BigInteger.ZERO;
 
     /** The primitive number type part of the sum */
-    private long mBuffer = 0;
+    private long mBuffer = 0L;
 
     /** Obtain the current sum
      * @return A BigInteger containing the sum of all numbers added */
     public BigInteger getSum() {
-        if (mBuffer != 0L)
+        if (mBuffer != 0L) {
             mSum = mSum.add(BigInteger.valueOf(mBuffer));
+            mBuffer = 0L;
+        }
         return mSum;
     }
 

--- a/lists/src/main/java/mathtools/lists/NumberComparison.java
+++ b/lists/src/main/java/mathtools/lists/NumberComparison.java
@@ -9,9 +9,10 @@ public final class NumberComparison {
     /** Determine if a Number and a Byte are equivalent
      * @param n The Number to compare
      * @param b The byte to compare
-     * @return True if n can be converted exactly to b */
+     * @return Whether the number can be converted without loss */
     public static boolean isEquivalent(
-            Number n, byte b
+            final Number n,
+            final byte b
     ) {
         if (n instanceof Byte)
             return n.equals(b);
@@ -37,9 +38,13 @@ public final class NumberComparison {
             return nStr.equals(String.valueOf(b));
     }
 
-    /**  */
+    /** Determine if a Number and a Short are equivalent
+     * @param n The Number to compare
+     * @param s The short to compare
+     * @return Whether the number can be converted without loss */
     public static boolean isEquivalent(
-            Number n, short s
+            final Number n,
+            final short s
     ) {
         if (n instanceof Short)
             return n.equals(s);

--- a/lists/src/main/java/mathtools/lists/NumberComparison.java
+++ b/lists/src/main/java/mathtools/lists/NumberComparison.java
@@ -1,0 +1,68 @@
+package mathtools.lists;
+
+/** Comparing Number Types
+ * @author DK96-OS : 2022 */
+public final class NumberComparison {
+
+    private NumberComparison() {}
+
+    /** Determine if a Number and a Byte are equivalent
+     * @param n The Number to compare
+     * @param b The byte to compare
+     * @return True if n can be converted exactly to b */
+    public static boolean isEquivalent(
+            Number n, byte b
+    ) {
+        if (n instanceof Byte)
+            return n.equals(b);
+        // Compare string representations
+        final String nStr = n.toString();
+        final int dotIndex = nStr.indexOf('.');
+        // Check floating point numbers
+        if (dotIndex > 0) {
+            // Check length of number
+            if (nStr.charAt(0) == '-') {
+                // Max size of a byte is 4 chars (-127)
+                if (dotIndex > 4) return false;
+                // If positive, then max size is 3 chars (127)
+            } else if (dotIndex > 3) return false;
+            // Check decimal place values are blank
+            if (nStr.endsWith(".0"))
+                // Check whole number place values equal
+                return nStr.substring(0, dotIndex)
+                        .equals(String.valueOf(b));
+            else
+                return false;
+        } else
+            return nStr.equals(String.valueOf(b));
+    }
+
+    /**  */
+    public static boolean isEquivalent(
+            Number n, short s
+    ) {
+        if (n instanceof Short)
+            return n.equals(s);
+        // Compare string representations
+        final String nStr = n.toString();
+        final int dotIndex = nStr.indexOf('.');
+        // Check floating point numbers
+        if (dotIndex > 0) {
+            // Check length of number
+            if (nStr.charAt(0) == '-') {
+                // Max size of a negative short is 6 chars (-32767)
+                if (dotIndex > 6) return false;
+                // If positive, then max size is 5 chars (32767)
+            } else if (dotIndex > 5) return false;
+            // Check decimal place values are blank
+            if (nStr.endsWith(".0"))
+                // Check whole number place values equal
+                return nStr.substring(0, dotIndex)
+                        .equals(String.valueOf(s));
+            else
+                return false;
+        } else
+            return nStr.equals(String.valueOf(s));
+    }
+
+}

--- a/lists/src/main/java/mathtools/lists/NumberListConversion.java
+++ b/lists/src/main/java/mathtools/lists/NumberListConversion.java
@@ -3,7 +3,7 @@ package mathtools.lists;
 import java.util.ArrayList;
 import java.util.List;
 
-/** Converts Numbered List Types
+/** Converts Numbered List Types - No validation of conversion accuracy
  * @author DK96-OS : 2022 */
 public final class NumberListConversion {
 

--- a/lists/src/main/java/mathtools/lists/NumberListConversionStrict.java
+++ b/lists/src/main/java/mathtools/lists/NumberListConversionStrict.java
@@ -6,6 +6,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import javax.annotation.Nonnull;
+
 /** Numbered List Conversion functions that are strict
  * @author DK96-OS : 2022 */
 public final class NumberListConversionStrict {
@@ -14,10 +16,12 @@ public final class NumberListConversionStrict {
 
     /** Attempts to convert to a list of bytes
      * @param list The input list to convert
-     * @param ignoreInvalid Whether to ignore invalid conversions, or throw exception */
+     * @param ignoreInvalid Whether to ignore errors, or throw exception
+     * @return A list of Bytes that were converted exactly */
+    @Nonnull
     public static List<Byte> toByteStrict(
-            List<Number> list,
-            boolean ignoreInvalid
+            @Nonnull final List<Number> list,
+            final boolean ignoreInvalid
     ) throws NumberFormatException {
         if (list.isEmpty())
             return Collections.emptyList();
@@ -29,6 +33,30 @@ public final class NumberListConversionStrict {
             else if (!ignoreInvalid)
                 throw new NumberFormatException(
                         "Cannot convert " + number + " to byte"
+                );
+        }
+        return newList;
+    }
+
+    /** Attempts to convert to a list of shorts
+     * @param list The input list to convert
+     * @param ignoreInvalid Whether to ignore errors, or throw exception
+     * @return A list of Short that were converted exactly */
+    @Nonnull
+    public static List<Short> toShortStrict(
+            @Nonnull final List<Number> list,
+            final boolean ignoreInvalid
+    ) throws NumberFormatException {
+        if (list.isEmpty())
+            return Collections.emptyList();
+        final ArrayList<Short> newList = new ArrayList<>(list.size());
+        for (Number number : list) {
+            final short b = number.shortValue();
+            if (isEquivalent(number, b))
+                newList.add(b);
+            else if (!ignoreInvalid)
+                throw new NumberFormatException(
+                        "Cannot convert " + number + " to short"
                 );
         }
         return newList;

--- a/lists/src/main/java/mathtools/lists/NumberListConversionStrict.java
+++ b/lists/src/main/java/mathtools/lists/NumberListConversionStrict.java
@@ -1,0 +1,37 @@
+package mathtools.lists;
+
+import static mathtools.lists.NumberComparison.isEquivalent;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Numbered List Conversion functions that are strict
+ * @author DK96-OS : 2022 */
+public final class NumberListConversionStrict {
+
+    private NumberListConversionStrict() {}
+
+    /** Attempts to convert to a list of bytes
+     * @param list The input list to convert
+     * @param ignoreInvalid Whether to ignore invalid conversions, or throw exception */
+    public static List<Byte> toByteStrict(
+            List<Number> list,
+            boolean ignoreInvalid
+    ) throws NumberFormatException {
+        if (list.isEmpty())
+            return Collections.emptyList();
+        final ArrayList<Byte> newList = new ArrayList<>(list.size());
+        for (Number number : list) {
+            final byte b = number.byteValue();
+            if (isEquivalent(number, b))
+                newList.add(b);
+            else if (!ignoreInvalid)
+                throw new NumberFormatException(
+                        "Cannot convert " + number + " to byte"
+                );
+        }
+        return newList;
+    }
+
+}

--- a/lists/src/main/java/mathtools/lists/arrays/ByteArrayExt.java
+++ b/lists/src/main/java/mathtools/lists/arrays/ByteArrayExt.java
@@ -1,6 +1,14 @@
 package mathtools.lists.arrays;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.Nonnull;
 
 /** Methods for operating on a byte array
  * @author DK96-OS : 2022 */
@@ -20,13 +28,38 @@ public final class ByteArrayExt {
     }
 
     /** Clears any nonzero elements in the Array
+     *  Uses java.util.Arrays.fill()
      * @param array The array to reset to all zero */
     public static void clear(
             @NotNull byte[] array
     ) {
-        for (int i = 0; i < array.length; i++) {
-            if (array[i] != 0) array[i] = 0;
+        Arrays.fill(array, (byte) 0);
+    }
+
+    /** Create a List from the values in an array */
+    @NonNull
+    public static List<Byte> toList(
+            @Nonnull final byte[] array
+    ) {
+        if (array.length < 5) switch (array.length) {
+            case 0: return Collections.emptyList();
+            case 1: return List.of(array[0]);
+            case 2: return List.of(array[0], array[1]);
+            case 3: return List.of(array[0], array[1], array[2]);
+            case 4: return List.of(array[0], array[1], array[2], array[3]);
         }
+        final ArrayList<Byte> list = new ArrayList<>(array.length);
+        for (byte i : array) list.add(i);
+        return list;
+    }
+
+    /** Determines whether all Integer values in this array are non-zero */
+    public static boolean allNonZero(
+            @Nonnull final byte[] array
+    ) {
+        for (byte j : array)
+            if (0 == j) return false;
+        return true;
     }
 
 }

--- a/lists/src/main/java/mathtools/lists/arrays/ByteArrayExt.java
+++ b/lists/src/main/java/mathtools/lists/arrays/ByteArrayExt.java
@@ -42,11 +42,11 @@ public final class ByteArrayExt {
             @Nonnull final byte[] array
     ) {
         if (array.length < 5) switch (array.length) {
-            case 0: return Collections.emptyList();
-            case 1: return List.of(array[0]);
-            case 2: return List.of(array[0], array[1]);
-            case 3: return List.of(array[0], array[1], array[2]);
             case 4: return List.of(array[0], array[1], array[2], array[3]);
+            case 3: return List.of(array[0], array[1], array[2]);
+            case 2: return List.of(array[0], array[1]);
+            case 1: return List.of(array[0]);
+            default: return Collections.emptyList();
         }
         final ArrayList<Byte> list = new ArrayList<>(array.length);
         for (byte i : array) list.add(i);

--- a/lists/src/main/java/mathtools/lists/arrays/IntArrayExt.java
+++ b/lists/src/main/java/mathtools/lists/arrays/IntArrayExt.java
@@ -33,11 +33,11 @@ public final class IntArrayExt {
             @Nonnull final int[] array
     ) {
         if (array.length < 5) switch (array.length) {
-            case 0: return Collections.emptyList();
-            case 1: return List.of(array[0]);
-            case 2: return List.of(array[0], array[1]);
-            case 3: return List.of(array[0], array[1], array[2]);
             case 4: return List.of(array[0], array[1], array[2], array[3]);
+            case 3: return List.of(array[0], array[1], array[2]);
+            case 2: return List.of(array[0], array[1]);
+            case 1: return List.of(array[0]);
+            default: return Collections.emptyList();
         }
         final ArrayList<Integer> list = new ArrayList<>(array.length);
         for (int i : array) list.add(i);

--- a/lists/src/main/java/mathtools/lists/arrays/IntArrayExt.java
+++ b/lists/src/main/java/mathtools/lists/arrays/IntArrayExt.java
@@ -1,6 +1,13 @@
 package mathtools.lists.arrays;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.Nonnull;
 
 /** Methods for operating on an int array
  * @author DK96-OS : 2022 */
@@ -18,6 +25,32 @@ public final class IntArrayExt {
         long sum = 0;
         for (int s : array) sum += s;
         return sum;
+    }
+
+    /** Create a List from the values in an array */
+    @NonNull
+    public static List<Integer> toList(
+            @Nonnull final int[] array
+    ) {
+        if (array.length < 5) switch (array.length) {
+            case 0: return Collections.emptyList();
+            case 1: return List.of(array[0]);
+            case 2: return List.of(array[0], array[1]);
+            case 3: return List.of(array[0], array[1], array[2]);
+            case 4: return List.of(array[0], array[1], array[2], array[3]);
+        }
+        final ArrayList<Integer> list = new ArrayList<>(array.length);
+        for (int i : array) list.add(i);
+        return list;
+    }
+
+    /** Determines whether all Integer values in this array are non-zero */
+    public static boolean allNonZero(
+            @Nonnull final int[] array
+    ) {
+        for (int j : array)
+            if (0 == j) return false;
+        return true;
     }
 
 }

--- a/lists/src/main/java/mathtools/lists/arrays/LongArrayExt.java
+++ b/lists/src/main/java/mathtools/lists/arrays/LongArrayExt.java
@@ -9,6 +9,8 @@ import java.util.List;
 
 import javax.annotation.Nonnull;
 
+import mathtools.lists.BigIntSumBuffer;
+
 /** Methods for operating on a long array
  * @author DK96-OS : 2022 */
 public final class LongArrayExt {
@@ -22,31 +24,12 @@ public final class LongArrayExt {
     public static BigInteger sum(
             @NotNull long[] array
     ) {
-        final long limit = Long.MAX_VALUE / 2;
-        BigInteger sum = BigInteger.ZERO;
-        long minorSum = 0;
-        for (long next : array) {
-            // values over limit get converted to BigInt immediately
-            if (next >= limit)
-                sum = sum.add(BigInteger.valueOf(next));
-            // the smaller sum can handle this value
-            else if (minorSum < limit)
-                minorSum += next;
-            // see if the addition overflows
-            else {
-                final long trySum = minorSum + next;
-                // check for overflow
-                if (trySum > minorSum)  // No overflow
-                    minorSum = trySum;
-                else {
-                    sum = sum.add(BigInteger.valueOf(minorSum));
-                    minorSum = next;
-                }
-            }
-        }
-        if (minorSum != 0L)
-            sum = sum.add(BigInteger.valueOf(minorSum));
-        return sum;
+        if (array.length == 0) return BigInteger.ZERO;
+        else if (array.length == 1) return BigInteger.valueOf(array[0]);
+        //
+        final BigIntSumBuffer buffer = new BigIntSumBuffer();
+        for (long next : array) buffer.add(next);
+        return buffer.getSum();
     }
 
     /** Create a List from the values in an array */

--- a/lists/src/main/java/mathtools/lists/arrays/LongArrayExt.java
+++ b/lists/src/main/java/mathtools/lists/arrays/LongArrayExt.java
@@ -52,11 +52,11 @@ public final class LongArrayExt {
             @Nonnull final long[] array
     ) {
         if (array.length < 5) switch (array.length) {
-            case 0: return Collections.emptyList();
-            case 1: return List.of(array[0]);
-            case 2: return List.of(array[0], array[1]);
-            case 3: return List.of(array[0], array[1], array[2]);
             case 4: return List.of(array[0], array[1], array[2], array[3]);
+            case 3: return List.of(array[0], array[1], array[2]);
+            case 2: return List.of(array[0], array[1]);
+            case 1: return List.of(array[0]);
+            default: return Collections.emptyList();
         }
         final ArrayList<Long> list = new ArrayList<>(array.length);
         for (long i : array) list.add(i);

--- a/lists/src/main/java/mathtools/lists/arrays/LongArrayExt.java
+++ b/lists/src/main/java/mathtools/lists/arrays/LongArrayExt.java
@@ -3,6 +3,11 @@ package mathtools.lists.arrays;
 import org.jetbrains.annotations.NotNull;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.Nonnull;
 
 /** Methods for operating on a long array
  * @author DK96-OS : 2022 */
@@ -40,5 +45,31 @@ public final class LongArrayExt {
             sum = sum.add(BigInteger.valueOf(minorSum));
         return sum;
     }
-    
+
+    /** Create a List from the values in an array */
+    @Nonnull
+    public static List<Long> toList(
+            @Nonnull final long[] array
+    ) {
+        if (array.length < 5) switch (array.length) {
+            case 0: return Collections.emptyList();
+            case 1: return List.of(array[0]);
+            case 2: return List.of(array[0], array[1]);
+            case 3: return List.of(array[0], array[1], array[2]);
+            case 4: return List.of(array[0], array[1], array[2], array[3]);
+        }
+        final ArrayList<Long> list = new ArrayList<>(array.length);
+        for (long i : array) list.add(i);
+        return list;
+    }
+
+    /** Determines whether all Short values in this array are non-zero */
+    public static boolean allNonZero(
+            @Nonnull final long[] array
+    ) {
+        for (long l : array)
+            if (0 == l) return false;
+        return true;
+    }
+
 }

--- a/lists/src/main/java/mathtools/lists/arrays/LongArrayExt.java
+++ b/lists/src/main/java/mathtools/lists/arrays/LongArrayExt.java
@@ -22,16 +22,19 @@ public final class LongArrayExt {
     public static BigInteger sum(
             @NotNull long[] array
     ) {
-        long limit = Long.MAX_VALUE / 2;
+        final long limit = Long.MAX_VALUE / 2;
         BigInteger sum = BigInteger.ZERO;
         long minorSum = 0;
         for (long next : array) {
+            // values over limit get converted to BigInt immediately
             if (next >= limit)
                 sum = sum.add(BigInteger.valueOf(next));
+            // the smaller sum can handle this value
             else if (minorSum < limit)
                 minorSum += next;
+            // see if the addition overflows
             else {
-                long trySum = minorSum + next;
+                final long trySum = minorSum + next;
                 // check for overflow
                 if (trySum > minorSum)  // No overflow
                     minorSum = trySum;

--- a/lists/src/main/java/mathtools/lists/arrays/ShortArrayExt.java
+++ b/lists/src/main/java/mathtools/lists/arrays/ShortArrayExt.java
@@ -2,6 +2,12 @@ package mathtools.lists.arrays;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.Nonnull;
+
 /** Methods for operating on a short array
  * @author DK96-OS : 2022 */
 public final class ShortArrayExt {
@@ -18,6 +24,32 @@ public final class ShortArrayExt {
         long sum = 0;
         for (short s : array) sum += s;
         return sum;
+    }
+
+    /** Create a List from the values in an array */
+    @Nonnull
+    public static List<Short> toList(
+            @Nonnull final short[] array
+    ) {
+        if (array.length < 5) switch (array.length) {
+            case 0: return Collections.emptyList();
+            case 1: return List.of(array[0]);
+            case 2: return List.of(array[0], array[1]);
+            case 3: return List.of(array[0], array[1], array[2]);
+            case 4: return List.of(array[0], array[1], array[2], array[3]);
+        }
+        final ArrayList<Short> list = new ArrayList<>(array.length);
+        for (short i : array) list.add(i);
+        return list;
+    }
+
+    /** Determines whether all Short values in this array are non-zero */
+    public static boolean allNonZero(
+            @Nonnull final short[] array
+    ) {
+        for (short value : array)
+            if (0 == value) return false;
+        return true;
     }
 
 }

--- a/lists/src/main/java/mathtools/lists/arrays/ShortArrayExt.java
+++ b/lists/src/main/java/mathtools/lists/arrays/ShortArrayExt.java
@@ -32,11 +32,11 @@ public final class ShortArrayExt {
             @Nonnull final short[] array
     ) {
         if (array.length < 5) switch (array.length) {
-            case 0: return Collections.emptyList();
-            case 1: return List.of(array[0]);
-            case 2: return List.of(array[0], array[1]);
-            case 3: return List.of(array[0], array[1], array[2]);
             case 4: return List.of(array[0], array[1], array[2], array[3]);
+            case 3: return List.of(array[0], array[1], array[2]);
+            case 2: return List.of(array[0], array[1]);
+            case 1: return List.of(array[0]);
+            default: return Collections.emptyList();
         }
         final ArrayList<Short> list = new ArrayList<>(array.length);
         for (short i : array) list.add(i);

--- a/lists/src/main/kotlin/mathtools/lists/DoubleList.kt
+++ b/lists/src/main/kotlin/mathtools/lists/DoubleList.kt
@@ -123,35 +123,18 @@ object DoubleList {
         return result
     }
 
-    /** Calculate a large sum.
-     * Note: Result may depend on order of elements in list */
+    /** Calculate a large sum
+     * @param list The values to add in the sum
+     * @return A BigDecimal containing the sum of all values */
     fun largeSum(
         list: List<Double>,
     ) : BigDecimal {
-        val limit: Double = Double.MAX_VALUE / 2
         var sum: BigDecimal = BigDecimal.ZERO
-        var minorSum = 0.0
         for (idx in list.indices) {
             val next = list[idx]
-            when {
-                // Next is over limit, just add
-                next >= limit -> sum += BigDecimal.valueOf(next)
-                // Minor sum below limit, safe to add next
-                minorSum < limit -> minorSum += next
-                else -> {
-                    val trySum = minorSum + next
-                    // Check for overflow
-                    if (trySum > minorSum) { // No overflow
-                        minorSum = trySum
-                    } else {
-                        sum += BigDecimal.valueOf(minorSum)
-                        minorSum = next
-                    }
-                }
-            }
+            if (next != 0.0)
+                sum = sum.add(BigDecimal.valueOf(next))
         }
-        if (minorSum > 0)
-            sum += BigDecimal.valueOf(minorSum)
         return sum
     }
 

--- a/lists/src/main/kotlin/mathtools/lists/IntList.kt
+++ b/lists/src/main/kotlin/mathtools/lists/IntList.kt
@@ -1,7 +1,6 @@
 package mathtools.lists
 
 import java.math.BigInteger
-import kotlin.math.roundToLong
 
 /** Functions of Integer typed Lists
  * @author DK96-OS : 2022 */
@@ -118,28 +117,13 @@ object IntList {
 	fun largeSum(
 		list: List<Int>,
 	) : BigInteger {
-		val limit: Long = (Long.MAX_VALUE * 0.96f).roundToLong()
-		var sum: BigInteger = BigInteger.ZERO
-		var minorSum = 0L
-		for (idx in list.indices) {
-			val next = list[idx]
-			when {
-				// Minor sum below limit, safe to add next
-				minorSum < limit -> minorSum += next
-				else -> {
-					val trySum: Long = minorSum + next
-					// Check for overflow
-					if (trySum > minorSum) minorSum = trySum // No overflow
-					else {
-						sum += BigInteger.valueOf(minorSum)
-						minorSum = next.toLong()
-					}
-				}
-			}
+		if (list.size < 2) return when (list.size) {
+			1 -> BigInteger.valueOf(list[0].toLong())
+			else -> BigInteger.ZERO
 		}
-		if (minorSum != 0L)
-			sum += BigInteger.valueOf(minorSum)
-		return sum
+		val buffer = BigIntSumBuffer()
+		for (i in list) buffer.add(i)
+		return buffer.sum
 	}
 
 }

--- a/lists/src/main/kotlin/mathtools/lists/ListTypes.kt
+++ b/lists/src/main/kotlin/mathtools/lists/ListTypes.kt
@@ -16,14 +16,10 @@ fun <T : Number> listSum(
         for (i in floatList.indices) sum += floatList[i]
         sum
     }
-    is Long -> LongList.largeSum(list as List<Long>)
-        .toDouble()
-    is Int -> {
-        val intList = list as List<Int>
-        var sum = 0L
-        for (i in intList.indices) sum += intList[i]
-        sum.toDouble()
-    }
+    is Long ->
+        LongList.largeSum(list as List<Long>).toDouble()
+    is Int ->
+        IntList.largeSum(list as List<Int>).toDouble()
     is Short -> {
         val shortList = list as List<Short>
         var sum = 0L

--- a/lists/src/main/kotlin/mathtools/lists/LongList.kt
+++ b/lists/src/main/kotlin/mathtools/lists/LongList.kt
@@ -121,31 +121,13 @@ object LongList {
     fun largeSum(
         list: List<Long>,
     ) : BigInteger {
-        val limit: Long = Long.MAX_VALUE / 2
-        var sum: BigInteger = BigInteger.ZERO
-        var minorSum = 0L
-        for (idx in list.indices) {
-            val next = list[idx]
-            when {
-                // Next is over limit, just add
-                next >= limit -> sum += BigInteger.valueOf(next)
-                // Minor sum below limit, safe to add next
-                minorSum < limit -> minorSum += next
-                else -> {
-                    val trySum = minorSum + next
-                    // Check for overflow
-                    if (trySum > minorSum) { // No overflow
-                        minorSum = trySum
-                    } else {
-                        sum += BigInteger.valueOf(minorSum)
-                        minorSum = next
-                    }
-                }
-            }
+        if (list.size < 2) return when (list.size) {
+            1 -> BigInteger.valueOf(list[0]);
+            else -> BigInteger.ZERO;
         }
-        if (minorSum != 0L)
-            sum += BigInteger.valueOf(minorSum)
-        return sum
+        val buffer = BigIntSumBuffer()
+        for (idx in list.indices) buffer.add(list[idx])
+        return buffer.sum
     }
 
 }

--- a/lists/src/main/kotlin/mathtools/lists/arrays/ByteArrayExtensions.kt
+++ b/lists/src/main/kotlin/mathtools/lists/arrays/ByteArrayExtensions.kt
@@ -6,11 +6,11 @@ object ByteArrayExtensions {
 
 	/** Clears any nonzero elements in the Array */
 	fun ByteArray.clear() {
-		val zero: Byte = 0
-		val first = indexOfFirst { it != zero }
-		if (first > -1)
-			for (i in first until size)
-				if (this[i] != (0).toByte()) set(i, 0)
+		ByteArrayExt.clear(this)
 	}
+
+	/** Determines whether this array contains only non-zero elements */
+	fun ByteArray.isNonZero()
+		: Boolean = ByteArrayExt.allNonZero(this)
 
 }

--- a/lists/src/main/kotlin/mathtools/lists/arrays/IntArrayExtensions.kt
+++ b/lists/src/main/kotlin/mathtools/lists/arrays/IntArrayExtensions.kt
@@ -2,17 +2,17 @@ package mathtools.lists.arrays
 
 import java.util.*
 
-/** Convenient ByteArray methods
+/** Convenient IntArray methods
  * @author DK96-OS : 2022 */
-object ByteArrayExtensions {
+object IntArrayExtensions {
 
 	/** Clears any nonzero elements in the Array */
-	fun ByteArray.clear() {
+	fun IntArray.clear() {
 		Arrays.fill(this, 0)
 	}
 
 	/** Determines whether this array contains only non-zero elements */
-	fun ByteArray.isNonZero()
-		: Boolean = ByteArrayExt.allNonZero(this)
+	fun IntArray.isNonZero()
+		: Boolean = IntArrayExt.allNonZero(this)
 
 }

--- a/lists/src/main/kotlin/mathtools/lists/arrays/LongArrayExtensions.kt
+++ b/lists/src/main/kotlin/mathtools/lists/arrays/LongArrayExtensions.kt
@@ -2,17 +2,17 @@ package mathtools.lists.arrays
 
 import java.util.*
 
-/** Convenient ByteArray methods
+/** Convenient LongArray methods
  * @author DK96-OS : 2022 */
-object ByteArrayExtensions {
+object LongArrayExtensions {
 
 	/** Clears any nonzero elements in the Array */
-	fun ByteArray.clear() {
+	fun LongArray.clear() {
 		Arrays.fill(this, 0)
 	}
 
 	/** Determines whether this array contains only non-zero elements */
-	fun ByteArray.isNonZero()
-		: Boolean = ByteArrayExt.allNonZero(this)
+	fun LongArray.isNonZero()
+		: Boolean = LongArrayExt.allNonZero(this)
 
 }

--- a/lists/src/main/kotlin/mathtools/lists/arrays/ShortArrayExtensions.kt
+++ b/lists/src/main/kotlin/mathtools/lists/arrays/ShortArrayExtensions.kt
@@ -2,17 +2,17 @@ package mathtools.lists.arrays
 
 import java.util.*
 
-/** Convenient ByteArray methods
+/** Convenient ShortArray methods
  * @author DK96-OS : 2022 */
-object ByteArrayExtensions {
+object ShortArrayExtensions {
 
 	/** Clears any nonzero elements in the Array */
-	fun ByteArray.clear() {
+	fun ShortArray.clear() {
 		Arrays.fill(this, 0)
 	}
 
 	/** Determines whether this array contains only non-zero elements */
-	fun ByteArray.isNonZero()
-		: Boolean = ByteArrayExt.allNonZero(this)
+	fun ShortArray.isNonZero()
+		: Boolean = ShortArrayExt.allNonZero(this)
 
 }

--- a/lists/src/test/java/mathtools/lists/BigIntSumBufferTest.java
+++ b/lists/src/test/java/mathtools/lists/BigIntSumBufferTest.java
@@ -9,7 +9,15 @@ import java.math.BigInteger;
 
 /** Testing [BigIntSumBuffer]
  * @author DK96-OS : 2022 */
-public class BigIntSumBufferTest {
+public final class BigIntSumBufferTest {
+
+    private static final BigInteger bigIntMax =
+            BigInteger.valueOf(Integer.MAX_VALUE);
+
+    private static final BigInteger bigLongMax =
+            BigInteger.valueOf(Long.MAX_VALUE);
+    private static final BigInteger bigLongMin =
+            BigInteger.valueOf(Long.MIN_VALUE);
 
     private BigIntSumBuffer mBuffer;
 
@@ -46,7 +54,6 @@ public class BigIntSumBufferTest {
         mBuffer.add(-2);
         assertEquals(
                 BigInteger.TWO.negate(), mBuffer.getSum());
-        System.out.println("Hi");
         //
         mBuffer.add(Integer.MIN_VALUE + 2);
         assertEquals(
@@ -58,29 +65,67 @@ public class BigIntSumBufferTest {
         final int largeInt = Integer.MAX_VALUE - 5;
         final BigInteger largeIntBig = BigInteger.valueOf(largeInt);
         //
-        mBuffer.add(largeInt);
-        assertEquals(
-                largeIntBig, mBuffer.getSum());
+        for (int i = 0; i < 10; i++) mBuffer.add(largeInt);
         //
-        mBuffer.add(largeInt);
         assertEquals(
-                largeIntBig.multiply(BigInteger.TWO), mBuffer.getSum());
+                largeIntBig.multiply(BigInteger.TEN),
+                mBuffer.getSum()
+        );
     }
 
     @Test
-    void testAddingNumbers() {
-        final long belowLimit = (Long.MAX_VALUE - 3) / 2;
+    void testLongsAndIntegers() {
+        final long belowLimit = BigIntSumBuffer.longLimit - 1;
         final BigInteger belowLimitBig = BigInteger.valueOf(belowLimit);
         //
         mBuffer.add(belowLimit);
-        assertEquals(
-                belowLimitBig, mBuffer.getSum());
-        //
+        mBuffer.add(belowLimit);
         mBuffer.add(Integer.MAX_VALUE);
+        //
         assertEquals(
-                belowLimitBig.add(BigInteger.valueOf(Integer.MAX_VALUE)),
+                belowLimitBig.multiply(BigInteger.TWO).add(bigIntMax),
                 mBuffer.getSum()
         );
+    }
+
+    @Test
+    void testIntegerNearLimit() {
+        mBuffer.setLongBuffer(
+                BigIntSumBuffer.intLimit);
+        mBuffer.add(
+                Integer.MAX_VALUE);
+        assertEquals(
+                bigLongMax, mBuffer.getSum());
+    }
+
+    @Test
+    void testNegativeIntegerNearLimit() {
+        mBuffer.setLongBuffer(
+                BigIntSumBuffer.intLimitNegative);
+        mBuffer.add(
+                Integer.MIN_VALUE);
+        assertEquals(
+                bigLongMin, mBuffer.getSum());
+    }
+
+    @Test
+    void testIntegerOverflow() {
+        mBuffer.setLongBuffer(
+                BigIntSumBuffer.intLimit + 1);
+        mBuffer.add(
+                Integer.MAX_VALUE);
+        assertEquals(
+                bigLongMax.add(BigInteger.ONE), mBuffer.getSum());
+    }
+
+    @Test
+    void testNegativeIntegerOverflow() {
+        mBuffer.setLongBuffer(
+                BigIntSumBuffer.intLimitNegative - 1);
+        mBuffer.add(
+                Integer.MIN_VALUE);
+        assertEquals(
+                bigLongMin.subtract(BigInteger.ONE), mBuffer.getSum());
     }
 
 }

--- a/lists/src/test/java/mathtools/lists/BigIntSumBufferTest.java
+++ b/lists/src/test/java/mathtools/lists/BigIntSumBufferTest.java
@@ -1,0 +1,86 @@
+package mathtools.lists;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+
+/** Testing [BigIntSumBuffer]
+ * @author DK96-OS : 2022 */
+public class BigIntSumBufferTest {
+
+    private BigIntSumBuffer mBuffer;
+
+    @BeforeEach
+    void testSetup() { mBuffer = new BigIntSumBuffer(); }
+
+    @Test
+    void testLimits() {
+        System.out.printf(
+                "Long Limits: %d < l < %d\n",
+                BigIntSumBuffer.longLimitNegative,
+                BigIntSumBuffer.longLimit
+        );
+        System.out.printf(
+                "Integer Limits: %d < l < %d",
+                BigIntSumBuffer.intLimitNegative,
+                BigIntSumBuffer.intLimit
+        );
+    }
+
+    @Test
+    void testNegativeLong() {
+        mBuffer.add(-2L);
+        assertEquals(
+                BigInteger.TWO.negate(), mBuffer.getSum());
+        //
+        mBuffer.add(Long.MIN_VALUE + 2L);
+        assertEquals(
+                BigInteger.valueOf(Long.MIN_VALUE), mBuffer.getSum());
+    }
+
+    @Test
+    void testNegativeInt() {
+        mBuffer.add(-2);
+        assertEquals(
+                BigInteger.TWO.negate(), mBuffer.getSum());
+        System.out.println("Hi");
+        //
+        mBuffer.add(Integer.MIN_VALUE + 2);
+        assertEquals(
+                BigInteger.valueOf(Integer.MIN_VALUE), mBuffer.getSum());
+    }
+
+    @Test
+    void testLargeInt() {
+        final int largeInt = Integer.MAX_VALUE - 5;
+        final BigInteger largeIntBig = BigInteger.valueOf(largeInt);
+        //
+        mBuffer.add(largeInt);
+        assertEquals(
+                largeIntBig, mBuffer.getSum());
+        //
+        mBuffer.add(largeInt);
+        assertEquals(
+                largeIntBig.multiply(BigInteger.TWO), mBuffer.getSum());
+    }
+
+    @Test
+    void testAddingNumbers() {
+        final long belowLimit = (Long.MAX_VALUE - 3) / 2;
+        final BigInteger belowLimitBig = BigInteger.valueOf(belowLimit);
+        //
+        mBuffer.add(belowLimit);
+        assertEquals(
+                belowLimitBig, mBuffer.getSum());
+        //
+        mBuffer.add(Integer.MAX_VALUE);
+        assertEquals(
+                belowLimitBig.add(BigInteger.valueOf(Integer.MAX_VALUE)),
+                mBuffer.getSum()
+        );
+    }
+
+}

--- a/lists/src/test/java/mathtools/lists/DoubleListLargeSumTest.java
+++ b/lists/src/test/java/mathtools/lists/DoubleListLargeSumTest.java
@@ -53,4 +53,22 @@ public final class DoubleListLargeSumTest {
         );
     }
 
+    @Test
+    void testNegativeValues() {
+        final double max = -Double.MAX_VALUE;
+        final BigDecimal bigMax = BigDecimal.valueOf(max);
+        assertEquals(
+                0, bigMax.compareTo(
+                        DoubleList.INSTANCE.largeSum(List.of(max))
+                )
+        );
+        final List<Double> list = new ArrayList<>();
+        for (int i = 0; i< 10; i++) list.add(max);
+        assertEquals(
+                0, bigMax.multiply(BigDecimal.TEN).compareTo(
+                        DoubleList.INSTANCE.largeSum(list)
+                )
+        );
+    }
+
 }

--- a/lists/src/test/java/mathtools/lists/DoubleListLargeSumTest.java
+++ b/lists/src/test/java/mathtools/lists/DoubleListLargeSumTest.java
@@ -1,0 +1,56 @@
+package mathtools.lists;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Testing [DoubleList.largeSum] method
+ * @author DK96-OS : 2022 */
+public final class DoubleListLargeSumTest {
+
+    @Test
+    void testEmptyList() {
+        assertEquals(
+                BigDecimal.ZERO,
+                DoubleList.INSTANCE.largeSum(Collections.emptyList())
+        );
+    }
+
+    @Test
+    void testSingleValuedList() {
+        assertEquals(
+                BigDecimal.valueOf(1.0),
+                DoubleList.INSTANCE.largeSum(List.of(1.0))
+        );
+        assertEquals(
+                BigDecimal.valueOf(33.56),
+                DoubleList.INSTANCE.largeSum(List.of(33.56))
+        );
+    }
+
+    @Test
+    void testMaxDouble() {
+        final double max = Double.MAX_VALUE;
+        final BigDecimal bigMax = BigDecimal.valueOf(max);
+        assertEquals(
+                0, bigMax.compareTo(
+                        DoubleList.INSTANCE.largeSum(List.of(max))
+                )
+        );
+        //
+        final List<Double> list = new ArrayList<>();
+        for (int i = 0; i < 10; i++)
+            list.add(Double.MAX_VALUE);
+        assertEquals(
+                0, bigMax.multiply(BigDecimal.TEN).compareTo(
+                        DoubleList.INSTANCE.largeSum(list)
+                )
+        );
+    }
+
+}

--- a/lists/src/test/java/mathtools/lists/NumberComparisonTest.java
+++ b/lists/src/test/java/mathtools/lists/NumberComparisonTest.java
@@ -1,0 +1,123 @@
+package mathtools.lists;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static mathtools.lists.NumberComparison.isEquivalent;
+
+import org.junit.jupiter.api.Test;
+
+/** Testing the NumberComparison functions
+ * @author DK96-OS : 2022 */
+public class NumberComparisonTest {
+
+    @Test
+    void testByteEquivalenceTrue() {
+        assertTrue(isEquivalent((byte) 100, (byte) 100));
+        assertTrue(isEquivalent((byte) -100, (byte) -100));
+        //
+        assertTrue(isEquivalent((short) 100, (byte) 100));
+        assertTrue(isEquivalent((short) -100, (byte) -100));
+        //
+        assertTrue(isEquivalent((int) -100, (byte) -100));
+        assertTrue(isEquivalent((long) -100, (byte) -100));
+    }
+
+    @Test
+    void testByteEquivalenceFalse() {
+        assertFalse(isEquivalent((byte) 33, (byte) 44));
+        assertFalse(isEquivalent((short) 200, (byte) 200));
+        assertFalse(isEquivalent((int) 200, (byte) 200));
+        assertFalse(isEquivalent((long) 200, (byte) 200));
+        //
+        assertFalse(isEquivalent((float) 200, (byte) 200));
+        assertFalse(isEquivalent((double) 200, (byte) 200));
+    }
+
+    @Test
+    void testByteEquivalenceFloatTrue() {
+        assertTrue(isEquivalent(0.0f, (byte) 0));
+        assertTrue(isEquivalent(0.0, (byte) 0));
+        assertTrue(isEquivalent(20.0f, (byte) 20));
+        assertTrue(isEquivalent(20.0, (byte) 20));
+        assertTrue(isEquivalent(120.0f, (byte) 120));
+        assertTrue(isEquivalent(120.0, (byte) 120));
+        //
+        assertTrue(isEquivalent(-120.0f, (byte) -120));
+        assertTrue(isEquivalent(-120.0, (byte) -120));
+        assertTrue(isEquivalent(-127.0f, (byte) -127));
+        assertTrue(isEquivalent(-127.0, (byte) -127));
+    }
+
+    @Test
+    void testByteEquivalenceFloatFalse() {
+        assertFalse(isEquivalent(0.1f, (byte) 0));
+        assertFalse(isEquivalent(0.1, (byte) 0));
+        assertFalse(isEquivalent(1.0001f, (byte) 1));
+        assertFalse(isEquivalent(1.0001, (byte) 1));
+        //
+        assertFalse(isEquivalent(-1.0001f, (byte) -1));
+        assertFalse(isEquivalent(-1.0001, (byte) -1));
+        assertFalse(isEquivalent(-0.0001f, (byte) -0));
+        assertFalse(isEquivalent(-0.0001, (byte) -0));
+        //
+        assertFalse(isEquivalent(-127.0001f, (byte) -127));
+        assertFalse(isEquivalent(-127.0001, (byte) -127));
+    }
+
+    @Test
+    void testShortEquivalenceTrue() {
+        assertTrue(isEquivalent((byte) 20, (short) 20));
+        assertTrue(isEquivalent((short) 20, (short) 20));
+        assertTrue(isEquivalent((int) 20, (short) 20));
+        assertTrue(isEquivalent((long) 20, (short) 20));
+        //
+        assertTrue(isEquivalent(20f, (short) 20));
+        assertTrue(isEquivalent(20.0, (short) 20));
+    }
+
+    @Test
+    void testShortEquivalenceFalse() {
+        assertFalse(isEquivalent((short) 33, (short) 44));
+        assertFalse(isEquivalent((short) -55, (short) 55));
+        //
+        assertFalse(isEquivalent((byte) 11, (short) 55));
+        assertFalse(isEquivalent((int) 11, (short) 55));
+        assertFalse(isEquivalent((long) 11, (short) 55));
+        //
+        assertFalse(isEquivalent((long) 327688, (short) 32767));
+        assertFalse(isEquivalent((long) 327688, (short) 32767));
+    }
+
+    @Test
+    void testShortEquivalenceFloatTrue() {
+        assertTrue(isEquivalent(24f, (short) 24));
+        assertTrue(isEquivalent(24.0, (short) 24));
+        assertTrue(isEquivalent(2888f, (short) 2888));
+        assertTrue(isEquivalent(2888.0, (short) 2888));
+        //
+        assertTrue(isEquivalent(-2888f, (short) -2888));
+        assertTrue(isEquivalent(-2888.0, (short) -2888));
+    }
+
+    @Test
+    void testShortEquivalenceFloatFalse() {
+        assertFalse(isEquivalent(25f, (short) 33));
+        assertFalse(isEquivalent(25.0, (short) 33));
+        assertFalse(isEquivalent(0.1f, (short) 0));
+        assertFalse(isEquivalent(0.1, (short) 0));
+        //
+        assertFalse(isEquivalent(-10.1f, (short) -10));
+        assertFalse(isEquivalent(-10.1, (short) -10));
+        assertFalse(isEquivalent(-10.001f, (short) -10));
+        assertFalse(isEquivalent(-10.001, (short) -10));
+        //
+        assertFalse(isEquivalent(327670f, (short) 32767));
+        assertFalse(isEquivalent(327670.0, (short) 32767));
+        assertFalse(isEquivalent(-327670f, (short) -32767));
+        assertFalse(isEquivalent(-327670.0, (short) -32767));
+        //
+        assertFalse(isEquivalent(32767.001f, (short) 32767));
+        assertFalse(isEquivalent(32767.001, (short) 32767));
+    }
+
+}

--- a/lists/src/test/java/mathtools/lists/NumberListConversionStrictTest.java
+++ b/lists/src/test/java/mathtools/lists/NumberListConversionStrictTest.java
@@ -1,0 +1,51 @@
+package mathtools.lists;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static mathtools.lists.NumberListConversionStrict.toByteStrict;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Testing the Strict NumberList Conversion functions
+ * @author DK96-OS : 2022 */
+public final class NumberListConversionStrictTest {
+
+    private static final List<Number> shortList = new ArrayList<>();
+    private static final List<Number> intList = new ArrayList<>();
+
+    static {
+        shortList.add((short) 100);
+        shortList.add((short) Short.MAX_VALUE);
+        //
+        intList.add((int) 100);
+        intList.add((int) Short.MAX_VALUE);
+        intList.add((int) Integer.MAX_VALUE);
+    }
+
+    @Test
+    void testByteIgnoreInvalid() {
+        List<Byte> result = toByteStrict(
+                shortList, true
+        );
+        assertEquals(1, result.size());
+        assertEquals((byte) 100, result.get(0));
+        // Convert the Int List
+        result = toByteStrict(
+                intList, true
+        );
+        assertEquals(1, result.size());
+        assertEquals((byte) 100, result.get(0));
+    }
+
+    @Test
+    void testByteThrowsInvalid() {
+        assertThrows(NumberFormatException.class, () ->
+                toByteStrict(shortList, false));
+        assertThrows(NumberFormatException.class, () ->
+                toByteStrict(intList, false));
+    }
+
+}

--- a/lists/src/test/java/mathtools/lists/NumberListConversionStrictTest.java
+++ b/lists/src/test/java/mathtools/lists/NumberListConversionStrictTest.java
@@ -1,29 +1,21 @@
 package mathtools.lists;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static mathtools.lists.NumberListConversionStrict.toByteStrict;
+import static mathtools.lists.NumberListConversionStrict.toShortStrict;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /** Testing the Strict NumberList Conversion functions
  * @author DK96-OS : 2022 */
 public final class NumberListConversionStrictTest {
 
-    private static final List<Number> shortList = new ArrayList<>();
-    private static final List<Number> intList = new ArrayList<>();
-
-    static {
-        shortList.add((short) 100);
-        shortList.add((short) Short.MAX_VALUE);
-        //
-        intList.add((int) 100);
-        intList.add((int) Short.MAX_VALUE);
-        intList.add((int) Integer.MAX_VALUE);
-    }
+    private final List<Number> shortList = NumberListTestResources.shortList;
+    private final List<Number> intList = NumberListTestResources.intList;
 
     @Test
     void testByteIgnoreInvalid() {
@@ -46,6 +38,29 @@ public final class NumberListConversionStrictTest {
                 toByteStrict(shortList, false));
         assertThrows(NumberFormatException.class, () ->
                 toByteStrict(intList, false));
+    }
+
+    @Test
+    void testShortIgnoreInvalid() {
+        List<Short> result = toShortStrict(
+                shortList, true
+        );
+        assertEquals(2, result.size());
+        assertEquals((short) 100, result.get(0));
+        // Convert the Int List
+        result = toShortStrict(
+                intList, true
+        );
+        assertEquals(2, result.size());
+        assertEquals((short) 100, result.get(0));
+    }
+
+    @Test
+    void testShortThrowsInvalid() {
+        assertDoesNotThrow(
+                () -> toShortStrict(shortList, false));
+        assertThrows(NumberFormatException.class, () ->
+                toShortStrict(intList, false));
     }
 
 }

--- a/lists/src/test/java/mathtools/lists/NumberListConversionTest.java
+++ b/lists/src/test/java/mathtools/lists/NumberListConversionTest.java
@@ -1,0 +1,39 @@
+package mathtools.lists;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Testing NumberList Conversion
+ * @author DK96-OS : 2022 */
+public final class NumberListConversionTest {
+
+    /**  */
+    @Test
+    void testShortToByte() {
+        ArrayList<Number> shortList = new ArrayList<>();
+        shortList.add((short) 100);
+        shortList.add((short) 200);
+        shortList.add((short) 400);
+        List<Byte> result = NumberListConversion.toByte(shortList);
+        assertEquals((byte) 100, result.get(0));
+        assertEquals((byte) (200 - 256), result.get(1));
+        assertEquals((byte) (400 - 256), result.get(2));
+    }
+
+    @Test
+    void testFloatToByte() {
+        ArrayList<Number> floatList = new ArrayList<>();
+        floatList.add(0.23f);
+        floatList.add(10.2f);
+        floatList.add(200.3f);
+        List<Byte> result = NumberListConversion.toByte(floatList);
+        assertEquals((byte) 0, result.get(0));
+        assertEquals((byte) 10, result.get(1));
+        assertEquals((byte) (200 - 256), result.get(2));
+    }
+
+}

--- a/lists/src/test/java/mathtools/lists/NumberListTestResources.java
+++ b/lists/src/test/java/mathtools/lists/NumberListTestResources.java
@@ -1,0 +1,22 @@
+package mathtools.lists;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Testing Resources
+ * @author DK96-OS : 2022 */
+public final class NumberListTestResources {
+
+    public static final List<Number> shortList = new ArrayList<>();
+    public static final List<Number> intList = new ArrayList<>();
+
+    static {
+        shortList.add((short) 100);
+        shortList.add((short) Short.MAX_VALUE);
+        //
+        intList.add((int) 100);
+        intList.add((int) Short.MAX_VALUE);
+        intList.add((int) Integer.MAX_VALUE);
+    }
+
+}

--- a/lists/src/test/java/mathtools/lists/arrays/ByteArrayExtTest.java
+++ b/lists/src/test/java/mathtools/lists/arrays/ByteArrayExtTest.java
@@ -2,6 +2,7 @@ package mathtools.lists.arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -38,6 +39,13 @@ public final class ByteArrayExtTest {
             assertEquals(
                     (byte) (i + 4), list.get(i));
         }
+    }
+
+    @Test
+    void testSum() {
+        final byte[] array = newArray(10, (byte) 7);
+        assertEquals(
+                70, ByteArrayExt.sum(array));
     }
 
 }

--- a/lists/src/test/java/mathtools/lists/arrays/ByteArrayExtTest.java
+++ b/lists/src/test/java/mathtools/lists/arrays/ByteArrayExtTest.java
@@ -6,13 +6,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.Arrays;
 import java.util.List;
 
 /** Testing the ByteArray extension functions
  * @author DK96-OS : 2022 */
 public final class ByteArrayExtTest {
-
-    private static final byte ZERO = 0;
 
     private static byte[] newArray(
             final int size,
@@ -21,9 +20,7 @@ public final class ByteArrayExtTest {
         if (size < 0 || size > 200_000_000)
             throw new IllegalArgumentException();
         final byte[] array = new byte[size];
-        for (int i = 0; i < size; i++) {
-            array[i] = (byte) (startVal + i);
-        }
+        Arrays.fill(array, startVal);
         return array;
     }
 
@@ -35,17 +32,15 @@ public final class ByteArrayExtTest {
         final List<Byte> list = ByteArrayExt.toList(
                 newArray(arraySize, (byte) 4)
         );
-        for (int i = 0; i < arraySize; i++) {
-            assertEquals(
-                    (byte) (i + 4), list.get(i));
-        }
+        for (int i = 0; i < arraySize; i++)
+            assertEquals((byte) 4, list.get(i));
     }
 
     @Test
     void testSum() {
-        final byte[] array = newArray(10, (byte) 7);
+        final byte[] array = newArray(8, (byte) 7);
         assertEquals(
-                70, ByteArrayExt.sum(array));
+                56, ByteArrayExt.sum(array));
     }
 
 }

--- a/lists/src/test/java/mathtools/lists/arrays/ByteArrayExtTest.java
+++ b/lists/src/test/java/mathtools/lists/arrays/ByteArrayExtTest.java
@@ -1,0 +1,43 @@
+package mathtools.lists.arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+
+/** Testing the ByteArray extension functions
+ * @author DK96-OS : 2022 */
+public final class ByteArrayExtTest {
+
+    private static final byte ZERO = 0;
+
+    private static byte[] newArray(
+            final int size,
+            final byte startVal
+    ) {
+        if (size < 0 || size > 200_000_000)
+            throw new IllegalArgumentException();
+        final byte[] array = new byte[size];
+        for (int i = 0; i < size; i++) {
+            array[i] = (byte) (startVal + i);
+        }
+        return array;
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2, 3, 4, 5})
+    void testToListBaseCases(
+            final int arraySize
+    ) {
+        final List<Byte> list = ByteArrayExt.toList(
+                newArray(arraySize, (byte) 4)
+        );
+        for (int i = 0; i < arraySize; i++) {
+            assertEquals(
+                    (byte) (i + 4), list.get(i));
+        }
+    }
+
+}

--- a/lists/src/test/java/mathtools/lists/arrays/IntArrayExtTest.java
+++ b/lists/src/test/java/mathtools/lists/arrays/IntArrayExtTest.java
@@ -2,6 +2,7 @@ package mathtools.lists.arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -35,6 +36,13 @@ public final class IntArrayExtTest {
             assertEquals(
                     (int) (i + 4), list.get(i));
         }
+    }
+
+    @Test
+    void testSum() {
+        final int[] array = newArray(10, Short.MAX_VALUE);
+        assertEquals(
+                10 * Short.MAX_VALUE, IntArrayExt.sum(array));
     }
 
 }

--- a/lists/src/test/java/mathtools/lists/arrays/IntArrayExtTest.java
+++ b/lists/src/test/java/mathtools/lists/arrays/IntArrayExtTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.Arrays;
 import java.util.List;
 
 /** Testing the IntegerArray extension functions
@@ -19,8 +20,7 @@ public final class IntArrayExtTest {
         if (size < 0 || size > 200_000_000)
             throw new IllegalArgumentException();
         final int[] array = new int[size];
-        for (int i = 0; i < size; i++)
-            array[i] = startVal + i;
+        Arrays.fill(array, startVal);
         return array;
     }
 
@@ -32,10 +32,8 @@ public final class IntArrayExtTest {
         final List<Integer> list = IntArrayExt.toList(
                 newArray(arraySize, 4)
         );
-        for (int i = 0; i < arraySize; i++) {
-            assertEquals(
-                    (int) (i + 4), list.get(i));
-        }
+        for (int i = 0; i < arraySize; i++)
+            assertEquals(4, list.get(i));
     }
 
     @Test

--- a/lists/src/test/java/mathtools/lists/arrays/IntArrayExtTest.java
+++ b/lists/src/test/java/mathtools/lists/arrays/IntArrayExtTest.java
@@ -1,0 +1,40 @@
+package mathtools.lists.arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+
+/** Testing the IntegerArray extension functions
+ * @author DK96-OS : 2022 */
+public final class IntArrayExtTest {
+
+    private static int[] newArray(
+            final int size,
+            final int startVal
+    ) {
+        if (size < 0 || size > 200_000_000)
+            throw new IllegalArgumentException();
+        final int[] array = new int[size];
+        for (int i = 0; i < size; i++)
+            array[i] = startVal + i;
+        return array;
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2, 3, 4, 5})
+    void testToListBaseCases(
+            final int arraySize
+    ) {
+        final List<Integer> list = IntArrayExt.toList(
+                newArray(arraySize, 4)
+        );
+        for (int i = 0; i < arraySize; i++) {
+            assertEquals(
+                    (int) (i + 4), list.get(i));
+        }
+    }
+
+}

--- a/lists/src/test/java/mathtools/lists/arrays/LongArrayExtTest.java
+++ b/lists/src/test/java/mathtools/lists/arrays/LongArrayExtTest.java
@@ -1,0 +1,42 @@
+package mathtools.lists.arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+
+/** Testing the LongArray extension functions
+ * @author DK96-OS : 2022 */
+public final class LongArrayExtTest {
+
+    private static final long ZERO = 0;
+
+    private static long[] newArray(
+            final int size,
+            final long startVal
+    ) {
+        if (size < 0 || size > 200_000_000)
+            throw new IllegalArgumentException();
+        final long[] array = new long[size];
+        for (int i = 0; i < size; i++) {
+            array[i] = startVal + i;
+        }
+        return array;
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2, 3, 4, 5})
+    void testToListBaseCases(
+            final int arraySize
+    ) {
+        final List<Long> list = LongArrayExt.toList(
+                newArray(arraySize, 4)
+        );
+        for (int i = 0; i < arraySize; i++)
+            assertEquals(
+                    i + 4, list.get(i));
+    }
+
+}

--- a/lists/src/test/java/mathtools/lists/arrays/LongArrayExtTest.java
+++ b/lists/src/test/java/mathtools/lists/arrays/LongArrayExtTest.java
@@ -70,4 +70,24 @@ public final class LongArrayExtTest {
         );
     }
 
+    @Test
+    void testSumOfQuarterMaxValues() {
+        final long quarterMax = ((Long.MAX_VALUE / 2) + 1) / 2;
+        final long[] array = newArray(8, quarterMax);
+        assertEquals(
+                eight.multiply(BigInteger.valueOf(quarterMax)),
+                LongArrayExt.sum(array)
+        );
+    }
+
+    @Test
+    void testSumOfNegativeValues() {
+        final long quarterMax = -((Long.MAX_VALUE / 2) + 1) / 2;
+        final long[] array = newArray(8, quarterMax);
+        assertEquals(
+                eight.multiply(BigInteger.valueOf(quarterMax)),
+                LongArrayExt.sum(array)
+        );
+    }
+
 }

--- a/lists/src/test/java/mathtools/lists/arrays/LongArrayExtTest.java
+++ b/lists/src/test/java/mathtools/lists/arrays/LongArrayExtTest.java
@@ -2,16 +2,21 @@ package mathtools.lists.arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.math.BigInteger;
 import java.util.List;
 
 /** Testing the LongArray extension functions
  * @author DK96-OS : 2022 */
 public final class LongArrayExtTest {
 
-    private static final long ZERO = 0;
+    private static final BigInteger longMax =
+            BigInteger.valueOf(Long.MAX_VALUE);
+
+    private static final BigInteger eight = BigInteger.valueOf(8);
 
     private static long[] newArray(
             final int size,
@@ -37,6 +42,33 @@ public final class LongArrayExtTest {
         for (int i = 0; i < arraySize; i++)
             assertEquals(
                     i + 4, list.get(i));
+    }
+
+    @Test
+    void testSumOfIntegerSizedValues() {
+        final long[] array = newArray(8, Integer.MAX_VALUE);
+        assertEquals(
+                BigInteger.valueOf(8L * Integer.MAX_VALUE),
+                LongArrayExt.sum(array));
+    }
+
+    @Test
+    void testSumOfMaxValues() {
+        final long[] array = newArray(8, Long.MAX_VALUE);
+        assertEquals(
+                longMax.multiply(eight),
+                LongArrayExt.sum(array)
+        );
+    }
+
+    @Test
+    void testSumOfHalfMaxValues() {
+        final long halfMax = (Long.MAX_VALUE - 1) / 2;
+        final long[] array = newArray(8, halfMax);
+        assertEquals(
+                eight.multiply(BigInteger.valueOf(halfMax)),
+                LongArrayExt.sum(array)
+        );
     }
 
 }

--- a/lists/src/test/java/mathtools/lists/arrays/LongArrayExtTest.java
+++ b/lists/src/test/java/mathtools/lists/arrays/LongArrayExtTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.math.BigInteger;
+import java.util.Arrays;
 import java.util.List;
 
 /** Testing the LongArray extension functions
@@ -25,9 +26,7 @@ public final class LongArrayExtTest {
         if (size < 0 || size > 200_000_000)
             throw new IllegalArgumentException();
         final long[] array = new long[size];
-        for (int i = 0; i < size; i++) {
-            array[i] = startVal + i;
-        }
+        Arrays.fill(array, startVal);
         return array;
     }
 
@@ -40,8 +39,7 @@ public final class LongArrayExtTest {
                 newArray(arraySize, 4)
         );
         for (int i = 0; i < arraySize; i++)
-            assertEquals(
-                    i + 4, list.get(i));
+            assertEquals(4, list.get(i));
     }
 
     @Test
@@ -49,7 +47,8 @@ public final class LongArrayExtTest {
         final long[] array = newArray(8, Integer.MAX_VALUE);
         assertEquals(
                 BigInteger.valueOf(8L * Integer.MAX_VALUE),
-                LongArrayExt.sum(array));
+                LongArrayExt.sum(array)
+        );
     }
 
     @Test
@@ -63,7 +62,7 @@ public final class LongArrayExtTest {
 
     @Test
     void testSumOfHalfMaxValues() {
-        final long halfMax = (Long.MAX_VALUE - 1) / 2;
+        final long halfMax = (Long.MAX_VALUE - 3) / 2;
         final long[] array = newArray(8, halfMax);
         assertEquals(
                 eight.multiply(BigInteger.valueOf(halfMax)),

--- a/lists/src/test/java/mathtools/lists/arrays/ShortArrayExtTest.java
+++ b/lists/src/test/java/mathtools/lists/arrays/ShortArrayExtTest.java
@@ -12,8 +12,6 @@ import java.util.List;
  * @author DK96-OS : 2022 */
 public final class ShortArrayExtTest {
 
-    private static final short ZERO = 0;
-
     private static short[] newArray(
             final int size,
             final short startVal

--- a/lists/src/test/java/mathtools/lists/arrays/ShortArrayExtTest.java
+++ b/lists/src/test/java/mathtools/lists/arrays/ShortArrayExtTest.java
@@ -1,14 +1,31 @@
 package mathtools.lists.arrays;
 
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
 
 /** Testing the ShortArray extension functions
  * @author DK96-OS : 2022 */
-public class ShortArrayExtTest {
+public final class ShortArrayExtTest {
 
-    private static final byte ZERO = 0;
+    private static final short ZERO = 0;
+
+    private static short[] newArray(
+            final int size,
+            final short startVal
+    ) {
+        if (size < 0 || size > 200_000_000)
+            throw new IllegalArgumentException();
+        final short[] array = new short[size];
+        for (int i = 0; i < size; i++) {
+            array[i] = (short) (startVal + i);
+        }
+        return array;
+    }
 
     @Test
     void testSum() {
@@ -29,6 +46,20 @@ public class ShortArrayExtTest {
         assertEquals(
                 149000, ShortArrayExt.sum(array)
         );
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2, 3, 4, 5})
+    void testToListBaseCases(
+            final int arraySize
+    ) {
+        final List<Short> list = ShortArrayExt.toList(
+                newArray(arraySize, (short) 4)
+        );
+        for (int i = 0; i < arraySize; i++) {
+            assertEquals(
+                    (short) (i + 4), list.get(i));
+        }
     }
 
 }

--- a/lists/src/test/kotlin/mathtools/lists/arrays/ByteArrayExtensionsTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/arrays/ByteArrayExtensionsTest.kt
@@ -1,8 +1,10 @@
 package mathtools.lists.arrays
 
 import mathtools.lists.arrays.ByteArrayExtensions.clear
-import org.junit.jupiter.api.Assertions.assertEquals
+import mathtools.lists.arrays.ByteArrayExtensions.isNonZero
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import java.util.*
 
 /** Testing ByteArray methods
  * @author DK96-OS : 2022 */
@@ -12,14 +14,14 @@ class ByteArrayExtensionsTest {
 
 	@Test
 	fun testClearArray() {
-		val array = ByteArray(20) { it.toByte() }
+		val array = ByteArray(8) { it.toByte() }
 		array.clear()
 		for (i in array.indices)
 			assertEquals(zero, array[i])
 		//
 		array[3] = -9
-		array[15] = 2
-		array[18] = -0
+		array[5] = 2
+		//
 		array.clear()
 		for (i in array.indices)
 			assertEquals(zero, array[i])
@@ -27,10 +29,20 @@ class ByteArrayExtensionsTest {
 
 	@Test
 	fun testClearArrayEmpty() {
-		val array = ByteArray(20)
+		val array = ByteArray(8)
 		array.clear()
 		for (i in array.indices)
 			assertEquals(zero, array[i])
+	}
+
+	@Test
+	fun testNonZero() {
+		val array = ByteArray(8)
+		assertFalse(array.isNonZero())
+		Arrays.fill(array, 5)
+		assertTrue(array.isNonZero())
+		array[6] = 0
+		assertFalse(array.isNonZero())
 	}
 
 }

--- a/lists/src/test/kotlin/mathtools/lists/arrays/IntArrayExtensionsTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/arrays/IntArrayExtensionsTest.kt
@@ -1,0 +1,48 @@
+package mathtools.lists.arrays
+
+import mathtools.lists.arrays.IntArrayExtensions.clear
+import mathtools.lists.arrays.IntArrayExtensions.isNonZero
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.util.*
+
+/** Testing IntArray methods
+ * @author DK96-OS : 2022 */
+class IntArrayExtensionsTest {
+
+	private val zero: Int = 0
+
+	@Test
+	fun testClearArray() {
+		val array = IntArray(8) { it }
+		array.clear()
+		for (i in array.indices)
+			assertEquals(zero, array[i])
+		//
+		array[3] = -9
+		array[5] = 2
+		//
+		array.clear()
+		for (i in array.indices)
+			assertEquals(zero, array[i])
+	}
+
+	@Test
+	fun testClearArrayEmpty() {
+		val array = IntArray(8)
+		array.clear()
+		for (i in array.indices)
+			assertEquals(zero, array[i])
+	}
+
+	@Test
+	fun testNonZero() {
+		val array = IntArray(8)
+		assertFalse(array.isNonZero())
+		Arrays.fill(array, 5)
+		assertTrue(array.isNonZero())
+		array[6] = zero
+		assertFalse(array.isNonZero())
+	}
+
+}

--- a/lists/src/test/kotlin/mathtools/lists/arrays/LongArrayExtensionsTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/arrays/LongArrayExtensionsTest.kt
@@ -1,0 +1,48 @@
+package mathtools.lists.arrays
+
+import mathtools.lists.arrays.LongArrayExtensions.clear
+import mathtools.lists.arrays.LongArrayExtensions.isNonZero
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.util.*
+
+/** Testing LongArray methods
+ * @author DK96-OS : 2022 */
+class LongArrayExtensionsTest {
+
+	private val zero: Long = 0L
+
+	@Test
+	fun testClearArray() {
+		val array = LongArray(8) { it.toLong() }
+		array.clear()
+		for (i in array.indices)
+			assertEquals(zero, array[i])
+		//
+		array[3] = -9
+		array[5] = 2
+		//
+		array.clear()
+		for (i in array.indices)
+			assertEquals(zero, array[i])
+	}
+
+	@Test
+	fun testClearArrayEmpty() {
+		val array = LongArray(8)
+		array.clear()
+		for (i in array.indices)
+			assertEquals(zero, array[i])
+	}
+
+	@Test
+	fun testNonZero() {
+		val array = LongArray(8)
+		assertFalse(array.isNonZero())
+		Arrays.fill(array, 5)
+		assertTrue(array.isNonZero())
+		array[6] = zero
+		assertFalse(array.isNonZero())
+	}
+
+}

--- a/lists/src/test/kotlin/mathtools/lists/arrays/ShortArrayExtensionsTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/arrays/ShortArrayExtensionsTest.kt
@@ -1,0 +1,48 @@
+package mathtools.lists.arrays
+
+import mathtools.lists.arrays.ShortArrayExtensions.clear
+import mathtools.lists.arrays.ShortArrayExtensions.isNonZero
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.util.*
+
+/** Testing ShortArray methods
+ * @author DK96-OS : 2022 */
+class ShortArrayExtensionsTest {
+
+	private val zero: Short = (0).toShort()
+
+	@Test
+	fun testClearArray() {
+		val array = ShortArray(8) { it.toShort() }
+		array.clear()
+		for (i in array.indices)
+			assertEquals(zero, array[i])
+		//
+		array[3] = -9
+		array[5] = 2
+		//
+		array.clear()
+		for (i in array.indices)
+			assertEquals(zero, array[i])
+	}
+
+	@Test
+	fun testClearArrayEmpty() {
+		val array = ShortArray(8)
+		array.clear()
+		for (i in array.indices)
+			assertEquals(zero, array[i])
+	}
+
+	@Test
+	fun testNonZero() {
+		val array = ShortArray(8)
+		assertFalse(array.isNonZero())
+		Arrays.fill(array, 5)
+		assertTrue(array.isNonZero())
+		array[6] = 0
+		assertFalse(array.isNonZero())
+	}
+
+}

--- a/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListFindGreaterThanTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListFindGreaterThanTest.kt
@@ -121,7 +121,19 @@ class DoubleListFindGreaterThanTest {
     }
 
     @Test
-    fun testBadIndexArgs() {
+    fun testInvalidLimitArgs() {
+        assertEquals(
+            emptyList<Int>(),
+            findGreaterThan(u101, Double.POSITIVE_INFINITY)
+        )
+        assertEquals(
+            emptyList<Int>(),
+            findGreaterThan(u101, Double.NaN)
+        )
+    }
+
+    @Test
+    fun testInvalidIndexArgs() {
         val res = Array<List<Int>?>(3) { null }
         res[0] = findGreaterThan(
             u101, 77.5, 99, 99

--- a/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListFindOutOfBoundsTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/doubles/DoubleListFindOutOfBoundsTest.kt
@@ -81,11 +81,23 @@ class DoubleListFindOutOfBoundsTest {
 	}
 
 	@Test
-	fun testBadArguments() {
+	fun testInvalidArguments() {
 		// Reversed Bounds
 		assertEquals(
 			0, findOutOfBounds(
 				u101, 60.0, 40.0
+			).size
+		)
+		// Upper Bound is NaN
+		assertEquals(
+			0, findOutOfBounds(
+				u101, 10.0, Double.NaN,
+			).size
+		)
+		// Lower Bound is NaN
+		assertEquals(
+			0, findOutOfBounds(
+				u101, Double.NaN, 20.0
 			).size
 		)
 	}

--- a/lists/src/test/kotlin/mathtools/lists/ints/IntListLargeSumTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/ints/IntListLargeSumTest.kt
@@ -11,6 +11,9 @@ import java.math.BigInteger
  * @author DK96-OS : 2022 */
 class IntListLargeSumTest {
 
+	private val limit = Integer.MAX_VALUE / 2
+	private val bigLimit = BigInteger.valueOf(limit.toLong())
+
 	@Test
 	fun testU101() {
 		val data = toInt(uniform101)
@@ -26,6 +29,33 @@ class IntListLargeSumTest {
 			data.add(Int.MAX_VALUE)
 		assertEquals(
 			BigInteger.valueOf(5000L * Int.MAX_VALUE), largeSum(data)
+		)
+	}
+
+	@Test
+	fun testSmallLists() {
+		assertEquals(
+			BigInteger.ZERO, largeSum(emptyList()))
+		//
+		assertEquals(
+			bigLimit, largeSum(listOf(limit)))
+		//
+		assertEquals(
+			bigLimit.multiply(BigInteger.TWO),
+			largeSum(listOf(limit, limit))
+		)
+	}
+
+	@Test
+	fun testNegativeValues() {
+		val value = -(limit + 1) / 2
+		val array = Array(8) { value }
+		//
+		assertEquals(
+			BigInteger.valueOf(value.toLong()).multiply(
+				BigInteger.valueOf(8)
+			),
+			largeSum(array.toList())
 		)
 	}
 

--- a/lists/src/test/kotlin/mathtools/lists/longs/LongListLargeSumTest.kt
+++ b/lists/src/test/kotlin/mathtools/lists/longs/LongListLargeSumTest.kt
@@ -11,6 +11,9 @@ import java.math.BigInteger
  * @author DK96-OS : 2022 */
 class LongListLargeSumTest {
 
+	private val limit = Long.MAX_VALUE / 2
+	private val bigLimit = BigInteger.valueOf(limit)
+
 	@Test
 	fun testU101() {
 		val data = toLong(uniform101)
@@ -28,6 +31,31 @@ class LongListLargeSumTest {
 		maxLong *= BigInteger.valueOf(5000)
 		assertEquals(
 			maxLong, largeSum(data)
+		)
+	}
+
+	@Test
+	fun testSmallLists() {
+		assertEquals(
+			BigInteger.ZERO, largeSum(emptyList()))
+		//
+		assertEquals(
+			bigLimit, largeSum(listOf(limit)))
+		//
+		assertEquals(
+			bigLimit.multiply(BigInteger.TWO),
+			largeSum(listOf(limit, limit))
+		)
+	}
+
+	@Test
+	fun testNegativeValues() {
+		val value = -(limit + 1) / 2
+		val array = Array(8) { value }
+		//
+		assertEquals(
+			BigInteger.valueOf(value).multiply(BigInteger.valueOf(8)),
+			largeSum(array.toList())
 		)
 	}
 


### PR DESCRIPTION
Add strict conversions for Number typed lists.

Validates that the conversion provides an equivalent representation, so that no information is lost.

Option is provided to ignore values that do not convert, or throw an exception.

Resolves #56 