### PR TITLE
Upgrade BytePrimeCache Max Prime To 509

### DIFF
--- a/numbers/src/main/kotlin/mathtools/numbers/primes/ShortPrimeCache.kt
+++ b/numbers/src/main/kotlin/mathtools/numbers/primes/ShortPrimeCache.kt
@@ -17,7 +17,7 @@ open class ShortPrimeCache
 
 	/** Storage for short primes */
 	private var shortArray: ShortArray = shortArrayOf(
-	    257, 263, 269, 271, 277, 281, 283, 293,
+		521, 523, 541, 547, 557, 563, 569, 571,
     )
 	private val shortQueue = ArrayDeque<Short>(12)	
 
@@ -94,7 +94,7 @@ open class ShortPrimeCache
 	override fun clear() {
 		shortQueue.clear()
 		shortArray = shortArrayOf(
-		    257, 263, 269, 271, 277, 281, 283, 293,
+			521, 523, 541, 547, 557, 563, 569, 571,
 		)
 		byteCache.clear()
 	}

--- a/numbers/src/test/java/mathtools/numbers/primes/PrimeTestDataProvider.java
+++ b/numbers/src/test/java/mathtools/numbers/primes/PrimeTestDataProvider.java
@@ -26,16 +26,36 @@ public final class PrimeTestDataProvider {
 		229, 233, 239, 241, 251
 	};
 
+	private static final int[] primes257To349 = {
+		257, 263, 269, 271, 277, 281, 283, 293,
+		307, 311, 313, 317, 331, 337, 347, 349
+	};
+
+	private static final int[] primes353To509 = {
+		353, 359, 367, 373, 379, 383, 389, 397,
+		401, 409, 419, 421, 431, 433, 439, 443,
+		449, 457, 461, 463, 467, 479, 487, 491,
+		499, 503, 509
+	};
+
 	/** Get a list of primes up to 349 */
 	@Nonnull
 	public static List<Integer> getPrimes349() {
 		return IntArrayExt.toList(
 			Ints.concat(
-				primes251,
-				new int[]{
-					257, 263, 269, 271, 277, 281, 283, 293,
-					307, 311, 313, 317, 331, 337, 347, 349
-				}
+				primes251, primes257To349
+			)
+		);
+	}
+
+	@Nonnull
+	public static List<Integer> getPrimes509() {
+		final int[] primes349 = Ints.concat(
+			primes251, primes257To349
+		);
+		return IntArrayExt.toList(
+			Ints.concat(
+				primes349, primes353To509
 			)
 		);
 	}

--- a/numbers/src/test/java/mathtools/numbers/primes/cache/BytePrimeCacheTest.java
+++ b/numbers/src/test/java/mathtools/numbers/primes/cache/BytePrimeCacheTest.java
@@ -22,7 +22,7 @@ import mathtools.numbers.primes.validate.PrimeValidation;
  * @author DK96-OS : 2022 */
 public final class BytePrimeCacheTest {
 
-	private final List<Integer> primeList = PrimeTestDataProvider.getPrimes251();
+	private final List<Integer> primeList = PrimeTestDataProvider.getPrimes509();
 
 	private BytePrimeCache cache;
 

--- a/numbers/src/test/java/mathtools/numbers/primes/cache/ShortPrimeCacheTest.java
+++ b/numbers/src/test/java/mathtools/numbers/primes/cache/ShortPrimeCacheTest.java
@@ -24,12 +24,8 @@ import mathtools.numbers.structs.IntPair;
  * @author DK96-OS : 2022 */
 public final class ShortPrimeCacheTest {
 
-	private final List<Integer> primeList = PrimeTestDataProvider.getPrimes349();
-	/* These are the indices for a selection of numbers in the prime list:
-    	assertEquals(199, primeList[45])
-    	assertEquals(251, primeList[53])
-    	assertEquals(349, primeList[69])
-    */
+	private final List<Integer> primeList = PrimeTestDataProvider.getPrimes509();
+
 	private final int maxPrimeIndex = primeList.size() - 1;
 
 	private ShortPrimeCache cache = null;

--- a/numbers/src/test/java/mathtools/numbers/primes/validate/PrimeValidationFindPrimeTest.java
+++ b/numbers/src/test/java/mathtools/numbers/primes/validate/PrimeValidationFindPrimeTest.java
@@ -103,7 +103,7 @@ public final class PrimeValidationFindPrimeTest {
 	@Test
 	public void testFindPrimeAboveMax() {
 		assertNull(
-			findPrime(253, byteCache));
+			findPrime(BytePrimeCache.MAX_PRIME + 2, byteCache));
 		assertNull(
 			findPrime(57599, byteCache));
 		//


### PR DESCRIPTION
Increase the efficiency and utility of Prime Caches by increasing the max prime number stored in the cache.

### Byte Prime Cache
The `BytePrimeCache` has the ability to store more prime numbers by shifting larger values into the Byte data type range.

At larger values where prime numbers are sparse, this translation technique is less effective. The goal here is to make a quick gain without adding complexity.