### PR TITLE
Implement ToString Method In Numbers Structs Pair Classes

### DIFF
--- a/numbers/src/main/java/mathtools/numbers/structs/BytePair.java
+++ b/numbers/src/main/java/mathtools/numbers/structs/BytePair.java
@@ -64,4 +64,9 @@ public class BytePair {
 			return false;
 	}
 
+	@Override
+	public String toString() {
+		return "(" + mFirst + ", " + mSecond + ")";
+	}
+
 }

--- a/numbers/src/main/java/mathtools/numbers/structs/BytePairFixed.java
+++ b/numbers/src/main/java/mathtools/numbers/structs/BytePairFixed.java
@@ -46,4 +46,9 @@ public class BytePairFixed {
 			return false;
 	}
 
+	@Override
+	public String toString() {
+		return "(" + first + ", " + second + ")";
+	}
+
 }

--- a/numbers/src/main/java/mathtools/numbers/structs/DoublePair.java
+++ b/numbers/src/main/java/mathtools/numbers/structs/DoublePair.java
@@ -58,4 +58,9 @@ public class DoublePair {
 			return false;
 	}
 
+	@Override
+	public String toString() {
+		return "(" + mFirst + ", " + mSecond + ")";
+	}
+
 }

--- a/numbers/src/main/java/mathtools/numbers/structs/DoublePairFixed.java
+++ b/numbers/src/main/java/mathtools/numbers/structs/DoublePairFixed.java
@@ -46,4 +46,9 @@ public class DoublePairFixed {
 			return false;
 	}
 
+	@Override
+	public String toString() {
+		return "(" + first + ", " + second + ")";
+	}
+
 }

--- a/numbers/src/main/java/mathtools/numbers/structs/FloatPair.java
+++ b/numbers/src/main/java/mathtools/numbers/structs/FloatPair.java
@@ -58,4 +58,9 @@ public class FloatPair {
 			return false;
 	}
 
+	@Override
+	public String toString() {
+		return "(" + mFirst + ", " + mSecond + ")";
+	}
+
 }

--- a/numbers/src/main/java/mathtools/numbers/structs/FloatPairFixed.java
+++ b/numbers/src/main/java/mathtools/numbers/structs/FloatPairFixed.java
@@ -46,4 +46,9 @@ public class FloatPairFixed {
 			return false;
 	}
 
+	@Override
+	public String toString() {
+		return "(" + first + ", " + second + ")";
+	}
+
 }

--- a/numbers/src/main/java/mathtools/numbers/structs/IntPair.java
+++ b/numbers/src/main/java/mathtools/numbers/structs/IntPair.java
@@ -58,4 +58,9 @@ public class IntPair {
 			return false;
 	}
 
+	@Override
+	public String toString() {
+		return "(" + mFirst + ", " + mSecond + ")";
+	}
+
 }

--- a/numbers/src/main/java/mathtools/numbers/structs/IntPairFixed.java
+++ b/numbers/src/main/java/mathtools/numbers/structs/IntPairFixed.java
@@ -45,5 +45,10 @@ public class IntPairFixed {
 		} else
 			return false;
 	}
-	
+
+	@Override
+	public String toString() {
+		return "(" + first + ", " + second + ")";
+	}
+
 }

--- a/numbers/src/main/java/mathtools/numbers/structs/LongPair.java
+++ b/numbers/src/main/java/mathtools/numbers/structs/LongPair.java
@@ -58,4 +58,9 @@ public class LongPair {
 			return false;
 	}
 
+	@Override
+	public String toString() {
+		return "(" + mFirst + ", " + mSecond + ")";
+	}
+
 }

--- a/numbers/src/main/java/mathtools/numbers/structs/LongPairFixed.java
+++ b/numbers/src/main/java/mathtools/numbers/structs/LongPairFixed.java
@@ -45,5 +45,10 @@ public class LongPairFixed {
 		} else
 			return false;
 	}
+
+	@Override
+	public String toString() {
+		return "(" + first + ", " + second + ")";
+	}
 	
 }

--- a/numbers/src/main/java/mathtools/numbers/structs/ShortPair.java
+++ b/numbers/src/main/java/mathtools/numbers/structs/ShortPair.java
@@ -58,4 +58,9 @@ public class ShortPair {
 			return false;
 	}
 
+	@Override
+	public String toString() {
+		return "(" + mFirst + ", " + mSecond + ")";
+	}
+
 }

--- a/numbers/src/main/java/mathtools/numbers/structs/ShortPairFixed.java
+++ b/numbers/src/main/java/mathtools/numbers/structs/ShortPairFixed.java
@@ -46,4 +46,9 @@ public class ShortPairFixed {
 			return false;
 	}
 
+	@Override
+	public String toString() {
+		return "(" + first + ", " + second + ")";
+	}
+
 }

--- a/numbers/src/test/java/mathtools/numbers/structs/BytePairFixedTest.java
+++ b/numbers/src/test/java/mathtools/numbers/structs/BytePairFixedTest.java
@@ -76,4 +76,12 @@ public final class BytePairFixedTest {
 		assertNotEquals(mPair, str);
 	}
 
+	@Test
+	void testToString() {
+		assertEquals(
+			"(1, 2)",
+			mPair.toString()
+		);
+	}
+
 }

--- a/numbers/src/test/java/mathtools/numbers/structs/BytePairTest.java
+++ b/numbers/src/test/java/mathtools/numbers/structs/BytePairTest.java
@@ -78,4 +78,22 @@ public final class BytePairTest {
 		assertNotEquals(mPair0, str);
 	}
 
+	@Test
+	void testToString() {
+		assertEquals(
+			"(0, 0)",
+			mPair0.toString()
+		);
+	}
+
+	@Test
+	void testToString_AfterSetValues() {
+		mPair0.setFirst((byte) 30);
+		mPair0.setSecond((byte) -45);
+		assertEquals(
+			"(30, -45)",
+			mPair0.toString()
+		);
+	}
+
 }

--- a/numbers/src/test/java/mathtools/numbers/structs/DoublePairFixedTest.java
+++ b/numbers/src/test/java/mathtools/numbers/structs/DoublePairFixedTest.java
@@ -72,4 +72,12 @@ public final class DoublePairFixedTest {
 		assertNotEquals(mPair, str);
 	}
 
+	@Test
+	void testToString() {
+		assertEquals(
+			"(1.0, " + Double.MAX_VALUE + ")",
+			mPair.toString()
+		);
+	}
+
 }

--- a/numbers/src/test/java/mathtools/numbers/structs/DoublePairTest.java
+++ b/numbers/src/test/java/mathtools/numbers/structs/DoublePairTest.java
@@ -78,4 +78,22 @@ public final class DoublePairTest {
 		assertNotEquals(mPair0, str);
 	}
 
+	@Test
+	void testToString() {
+		assertEquals(
+			"(0.0, 0.0)",
+			mPair0.toString()
+		);
+	}
+
+	@Test
+	void testToString_AfterSetValues() {
+		mPair0.setFirst(301.5f);
+		mPair0.setSecond(-450f);
+		assertEquals(
+			"(301.5, -450.0)",
+			mPair0.toString()
+		);
+	}
+
 }

--- a/numbers/src/test/java/mathtools/numbers/structs/FloatPairFixedTest.java
+++ b/numbers/src/test/java/mathtools/numbers/structs/FloatPairFixedTest.java
@@ -79,4 +79,12 @@ public final class FloatPairFixedTest {
 		assertNotEquals(mPair, str);
 	}
 
+	@Test
+	void testToString() {
+		assertEquals(
+			"(1.0, " + Float.MAX_VALUE + ")",
+			mPair.toString()
+		);
+	}
+
 }

--- a/numbers/src/test/java/mathtools/numbers/structs/FloatPairTest.java
+++ b/numbers/src/test/java/mathtools/numbers/structs/FloatPairTest.java
@@ -77,5 +77,23 @@ public final class FloatPairTest {
 		String str = "";
 		assertNotEquals(mPair0, str);
 	}
-	
+
+	@Test
+	void testToString() {
+		assertEquals(
+			"(0.0, 0.0)",
+			mPair0.toString()
+		);
+	}
+
+	@Test
+	void testToString_AfterSetValues() {
+		mPair0.setFirst(301.5f);
+		mPair0.setSecond(-450f);
+		assertEquals(
+			"(301.5, -450.0)",
+			mPair0.toString()
+		);
+	}
+
 }

--- a/numbers/src/test/java/mathtools/numbers/structs/IntPairFixedTest.java
+++ b/numbers/src/test/java/mathtools/numbers/structs/IntPairFixedTest.java
@@ -72,4 +72,12 @@ public final class IntPairFixedTest {
 		assertNotEquals(mPair, str);
 	}
 
+	@Test
+	void testToString() {
+		assertEquals(
+			"(1, 2)",
+			mPair.toString()
+		);
+	}
+
 }

--- a/numbers/src/test/java/mathtools/numbers/structs/IntPairTest.java
+++ b/numbers/src/test/java/mathtools/numbers/structs/IntPairTest.java
@@ -81,4 +81,23 @@ public final class IntPairTest {
 		String str = "";
 		assertFalse(mPair0.equals(str));
 	}
+
+	@Test
+	void testToString() {
+		assertEquals(
+			"(0, 0)",
+			mPair0.toString()
+		);
+	}
+
+	@Test
+	void testToString_AfterSetValues() {
+		mPair0.setFirst((short) 301);
+		mPair0.setSecond((short) -450);
+		assertEquals(
+			"(301, -450)",
+			mPair0.toString()
+		);
+	}
+
 }

--- a/numbers/src/test/java/mathtools/numbers/structs/LongPairFixedTest.java
+++ b/numbers/src/test/java/mathtools/numbers/structs/LongPairFixedTest.java
@@ -72,4 +72,12 @@ public final class LongPairFixedTest {
 		assertNotEquals(mPair, str);
 	}
 
+	@Test
+	void testToString() {
+		assertEquals(
+			"(" + number1 + ", " + number2 +")",
+			mPair.toString()
+		);
+	}
+
 }

--- a/numbers/src/test/java/mathtools/numbers/structs/LongPairTest.java
+++ b/numbers/src/test/java/mathtools/numbers/structs/LongPairTest.java
@@ -79,4 +79,22 @@ public final class LongPairTest {
 		assertFalse(mPair0.equals(str));
 	}
 
+	@Test
+	void testToString() {
+		assertEquals(
+			"(0, 0)",
+			mPair0.toString()
+		);
+	}
+
+	@Test
+	void testToString_AfterSetValues() {
+		mPair0.setFirst((short) 301);
+		mPair0.setSecond((short) -450);
+		assertEquals(
+			"(301, -450)",
+			mPair0.toString()
+		);
+	}
+
 }

--- a/numbers/src/test/java/mathtools/numbers/structs/ShortPairFixedTest.java
+++ b/numbers/src/test/java/mathtools/numbers/structs/ShortPairFixedTest.java
@@ -72,4 +72,12 @@ public final class ShortPairFixedTest {
 		assertNotEquals(mPair, str);
 	}
 
+	@Test
+	void testToString() {
+		assertEquals(
+			"(128, -129)",
+			mPair.toString()
+		);
+	}
+
 }

--- a/numbers/src/test/java/mathtools/numbers/structs/ShortPairTest.java
+++ b/numbers/src/test/java/mathtools/numbers/structs/ShortPairTest.java
@@ -81,4 +81,22 @@ public final class ShortPairTest {
 		assertNotEquals(mPair0, str);
 	}
 
+	@Test
+	void testToString() {
+		assertEquals(
+			"(0, 0)",
+			mPair0.toString()
+		);
+	}
+
+	@Test
+	void testToString_AfterSetValues() {
+		mPair0.setFirst((short) 301);
+		mPair0.setSecond((short) -450);
+		assertEquals(
+			"(301, -450)",
+			mPair0.toString()
+		);
+	}
+
 }


### PR DESCRIPTION
Improve all Numbers Structs Pair Classes by implementing ToString Method.

Does not remove trailing decimal in Float and Decimal classes.