### PR TITLE
Release 0.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,23 +14,25 @@ Software Tools for Applied Mathematics are categorized into these modules:
 - [__Statistics__](https://github.com/DK96-OS/MathTools/wiki/Statistics-Module)
 
 ### Import in Gradle Build Script
-Choose The Modules that you want to import
-
-	dependencies {  
+Choose The Modules that you want to import:
+	def mt_version = "0.7.1"
+	dependencies {
 		implementation 'io.github.dk96-os:arrays:$mt_version'
 		implementation 'io.github.dk96-os:arrays-ktx:$mt_version'
+		implementation 'io.github.dk96-os:format:$mt_version'
+		implementation 'io.github.dk96-os:generators:$mt_version'
 		implementation 'io.github.dk96-os:lists:$mt_version'
 		implementation 'io.github.dk96-os:lists-ktx:$mt_version'
-		implementation 'io.github.dk96-os:statistics:$mt_version'
 		implementation 'io.github.dk96-os:numbers:$mt_version'
-		implementation 'io.github.dk96-os:generators:$mt_version'
+		implementation 'io.github.dk96-os:pairs:$mt_version'
+		implementation 'io.github.dk96-os:statistics:$mt_version'
 	}
 
 ___
 
-## Modules
+## MathTools Modules
 Each module is published as a package that can be downloaded from GitHub packages.
-Some modules depend on each other, but this number of dependencies has been kept at a minimum.
+Some modules depend on each other, but cross-module dependencies have been minimized.
 
 ### Arrays
 Numerical array operations not included in the standard library.

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 
 Software Tools for Applied Mathematics are categorized into these modules:
 ### Modules
-- [__Arrays__]()
-- [__Format__]()
-- [__Generators__](https://github.com/DK96-OS/MathTools/wiki/Generators-Module)
-- [__Lists__](https://github.com/DK96-OS/MathTools/wiki/Lists-Module)
-- [__Numbers__](https://github.com/DK96-OS/MathTools/wiki/Numbers-Module)
-- [__Pairs__]()
-- [__Statistics__](https://github.com/DK96-OS/MathTools/wiki/Statistics-Module)
+- __Arrays__
+- __Format__
+- __Generators__
+- __Lists__
+- __Numbers__
+- __Pairs__
+- __Statistics__
 
 ### Import in Gradle Build Script
 Choose The Modules that you want to import:
@@ -83,4 +83,4 @@ Process lists and arrays of primitive Number types, to determine statistical cha
 - Outlier Detection Policy
 
 ____
-For additional information, see the [Project Wiki](https://github.com/DK96-OS/MathTools/wiki)!
+For additional information, see the [Project Wiki](https://github.com/DK96-OS/MathTools/wiki)

--- a/README.md
+++ b/README.md
@@ -4,17 +4,16 @@
 Software Tools for Applied Mathematics are categorized into these modules:
 ### Modules
 - [__Arrays__]()
-- [__Arrays-ktx__]()
 - [__Format__]()
 - [__Generators__](https://github.com/DK96-OS/MathTools/wiki/Generators-Module)
 - [__Lists__](https://github.com/DK96-OS/MathTools/wiki/Lists-Module)
-- [__Lists-ktx__](https://github.com/DK96-OS/MathTools/wiki/Lists-Module)
 - [__Numbers__](https://github.com/DK96-OS/MathTools/wiki/Numbers-Module)
 - [__Pairs__]()
 - [__Statistics__](https://github.com/DK96-OS/MathTools/wiki/Statistics-Module)
 
 ### Import in Gradle Build Script
 Choose The Modules that you want to import:
+
 	def mt_version = "0.7.1"
 	dependencies {
 		implementation 'io.github.dk96-os:arrays:$mt_version'

--- a/artifacts.gradle
+++ b/artifacts.gradle
@@ -1,4 +1,4 @@
-def commonArtifactVersion = "0.7"
+def commonArtifactVersion = "0.7.1"
 ext {
     artifactVersions = [
             arrays : commonArtifactVersion,

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 pluginManagement {
 	plugins {
-		id "org.jetbrains.kotlin.jvm" version "1.9.10"
+		id "org.jetbrains.kotlin.jvm" version "1.9.20"
 		id "org.jetbrains.dokka" version "1.9.10"
 	}
 	repositories {

--- a/statistics/src/main/kotlin/mathtools/statistics/Statistics.kt
+++ b/statistics/src/main/kotlin/mathtools/statistics/Statistics.kt
@@ -7,17 +7,6 @@ import kotlin.math.sqrt
  * @author DK96-OS : 2022 */
 object Statistics {
 
-	/** Return true once every x times this function is called */
-	@Deprecated(
-		"Use Probability class"
-	)
-	fun oneIn(
-		x: Int,
-	) : Boolean = if (1 < x)
-		x * Math.random() < 0.9999999f
-	else
-		1 == x
-
 	/** Calculate the mean (average) value of the elements in a Number List
 	 * 	 */
     fun <T : Number> calculateMean(

--- a/statistics/src/test/java/mathtools/statistics/probability/ProbabilityTest.java
+++ b/statistics/src/test/java/mathtools/statistics/probability/ProbabilityTest.java
@@ -14,32 +14,36 @@ import java.util.Random;
 public final class ProbabilityTest {
 
 	private Random mRandom;
-	private Probability mProbability;
+	private Probability mInstance;
 
 	@BeforeEach
 	public void testSetup() {
 		mRandom = new Random(400L);
-		mProbability = new Probability(mRandom);
+		mInstance = new Probability(mRandom);
 	}
 
 	@Test
-	public void testOneInOne() {
+	public void testOneIn_One_ReturnsTrue() {
 		for (
 			byte i = 0; 10 > i; ++i
 		) assertTrue(
-			mProbability.oneIn(1)
+			mInstance.oneIn(1)
 		);
 	}
 
 	@Test
-	public void testInvalidInputs() {
+	public void testOneIn_InvalidInput_Zero_ThrowsException() {
 		assertThrows(
 			IllegalArgumentException.class,
-			() -> mProbability.oneIn(0)
+			() -> mInstance.oneIn(0)
 		);
+	}
+
+	@Test
+	public void testOneIn_InvalidInput_Negative1_ThrowsException() {
 		assertThrows(
 			IllegalArgumentException.class,
-			() -> mProbability.oneIn(-1)
+			() -> mInstance.oneIn(-1)
 		);
 	}
 

--- a/statistics/src/test/kotlin/mathtools/statistics/StatisticsOneInTest.kt
+++ b/statistics/src/test/kotlin/mathtools/statistics/StatisticsOneInTest.kt
@@ -1,6 +1,6 @@
 package mathtools.statistics
 
-import mathtools.statistics.Statistics.oneIn
+import mathtools.statistics.probability.Probability
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Tag
@@ -9,6 +9,13 @@ import org.junit.jupiter.api.Test
 /** Testing [Statistics] oneIn function
  * @author DK96-OS : 2022 */
 class StatisticsOneInTest {
+
+    /** The OneIn method has been replaced by Probability class.
+     *  The Probability class provides more control over the random algorithm.
+     */
+    val p = Probability()
+
+    private fun oneIn(x: Int): Boolean = p.oneIn(x)
 
     @Test
     fun testOne() {

--- a/statistics/src/test/kotlin/mathtools/statistics/StatisticsOneInTest.kt
+++ b/statistics/src/test/kotlin/mathtools/statistics/StatisticsOneInTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 /** Testing [Statistics] oneIn function
  * @author DK96-OS : 2022 */
@@ -24,13 +25,17 @@ class StatisticsOneInTest {
     }
 
     @Test
-    fun testInvalidInputs() {
-        assertFalse(
+    fun testInvalidInput_Zero_ThrowsException() {
+        assertThrows<IllegalArgumentException> {
             oneIn(0)
-        )
-        assertFalse(
+        }
+    }
+
+    @Test
+    fun testInvalidInput_Negative1_ThrowsException() {
+        assertThrows<IllegalArgumentException> {
             oneIn(-1)
-        )
+        }
     }
 
     @RepeatedTest(2)

--- a/statistics/src/test/kotlin/mathtools/statistics/StatisticsOneInTest.kt
+++ b/statistics/src/test/kotlin/mathtools/statistics/StatisticsOneInTest.kt
@@ -15,7 +15,7 @@ class StatisticsOneInTest {
      */
     val p = Probability()
 
-    private fun oneIn(x: Int): Boolean = p.oneIn(x)
+    private val oneIn: (x: Int) -> Boolean = p::oneIn
 
     @Test
     fun testOne() {

--- a/statistics/src/test/kotlin/mathtools/statistics/probability/ProbabilityMeasurementTest.kt
+++ b/statistics/src/test/kotlin/mathtools/statistics/probability/ProbabilityMeasurementTest.kt
@@ -1,42 +1,19 @@
-package mathtools.statistics
+package mathtools.statistics.probability
 
-import mathtools.statistics.probability.Probability
+import mathtools.statistics.Statistics
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Tag
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
-/** Testing [Statistics] oneIn function
- * @author DK96-OS : 2022 */
-class StatisticsOneInTest {
+/** Testing [Probability] by measuring a large number of outputs.
+ * @author DK96-OS : 2022
+ */
+class ProbabilityMeasurementTest {
 
     /** The OneIn method has been replaced by Probability class.
      *  The Probability class provides more control over the random algorithm.
      */
-    val p = Probability()
-
-    private val oneIn: (x: Int) -> Boolean = p::oneIn
-
-    @Test
-    fun testOne() {
-        for (i in 0 until 10)
-            assertTrue(oneIn(1))
-    }
-
-    @Test
-    fun testInvalidInput_Zero_ThrowsException() {
-        assertThrows<IllegalArgumentException> {
-            oneIn(0)
-        }
-    }
-
-    @Test
-    fun testInvalidInput_Negative1_ThrowsException() {
-        assertThrows<IllegalArgumentException> {
-            oneIn(-1)
-        }
-    }
+    private val p = Probability()
 
     @RepeatedTest(2)
     fun testOneIn2To9Probability() {
@@ -99,23 +76,32 @@ class StatisticsOneInTest {
     }
 
     /** Runs the Statistics OneIn( x ) function N times.
-     * N must end in a zero; it must be integer divisible by 10   */
-    private fun checkPercentage(x: Int, N: Long): Float {
+     * N must end in a zero; it must be integer divisible by 10.
+     */
+    private fun checkPercentage(
+        x: Int,
+        N: Long,
+    ) : Float {
         var trueCount = 0L
         for (i in 0 until N)
-            if (oneIn(x)) trueCount++
+            if (p.oneIn(x))
+                trueCount++
         return trueCount * 100f / N
     }
 
     /** Create a list of Measurements for OneIn output Statistics
      * @param x The input to oneIn.
-     * @param nFactor A factor in determining the number of trials per measurement
-     * @param measurements The number of times to measure the percentage independently */
+     * @param nFactor A factor in determining the number of trials per measurement.
+     * @param measurements The number of times to measure the percentage independently.
+     */
     private fun measureOneIn(
-        x: Int, nFactor: Long = 25_000L,
+        x: Int,
+        nFactor: Long = 25_000L,
         measurements: Int = 10,
     ) : List<Float> = Array(measurements) {
-        checkPercentage(x, x * nFactor)
-    }.toList()
+        checkPercentage(
+            x, x * nFactor
+        )
+    }.asList()
 
 }


### PR DESCRIPTION
### Upgrade Dependencies
- Kotlin 1.9.20

Fix README

### Statistics Module
Remove deprecated `Statistics` Kotlin object's `oneIn` method.
See `StatisticsOneInTest` commit 5fd05f475ae09cc572482fa98e3099aca358467a for a quick example of how to replace it with the `Probability` class.
Also view commit 7194b91667d4c836faad1283e431e4fb694a1522 for cool language feature alternative.

Note that the `Probability` `oneIn` method implementation throws `IllegalArgumentException` when input is invalid (input < 1). The `Statistics` `oneIn` method implementation returned false instead.